### PR TITLE
Fixing missing advances in parse, trimming whitespace

### DIFF
--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -45,10 +45,8 @@ func goblInvoice(in *Invoice) (*bill.Invoice, error) {
 
 	// Payment comprised of terms, means and payee. Check tehre is relevant info in at least one of them to create a payment
 	ahts := in.Transaction.Settlement
-	if ahts.HasPayment() {
-		if out.Payment, err = goblNewPaymentDetails(ahts); err != nil {
-			return nil, err
-		}
+	if out.Payment, err = goblNewPaymentDetails(ahts); err != nil {
+		return nil, err
 	}
 
 	if len(in.ExchangedDocument.IncludedNote) > 0 {

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -26,7 +26,7 @@ func goblAddLines(in *Transaction, out *bill.Invoice) error {
 			//If Quantity is not present, assume 1
 			Quantity: num.MakeAmount(1, 0),
 			Item: &org.Item{
-				Name:  it.Product.Name,
+				Name:  strings.TrimSpace(it.Product.Name),
 				Price: &price,
 			},
 			Taxes: tax.Set{
@@ -75,7 +75,7 @@ func goblAddLines(in *Transaction, out *bill.Invoice) error {
 		}
 
 		if it.Product.Description != nil {
-			l.Item.Description = *it.Product.Description
+			l.Item.Description = strings.TrimSpace(*it.Product.Description)
 		}
 
 		if it.Product.Origin != nil {
@@ -87,7 +87,7 @@ func goblAddLines(in *Transaction, out *bill.Invoice) error {
 			for _, note := range it.LineDoc.Note {
 				n := &org.Note{}
 				if note.Content != "" {
-					n.Text = note.Content
+					n.Text = strings.TrimSpace(note.Content)
 				}
 				if note.SubjectCode != "" {
 					n.Key = cbc.Key(note.SubjectCode)

--- a/settlement_parse.go
+++ b/settlement_parse.go
@@ -64,7 +64,7 @@ func goblNewPaymentDetails(stlm *Settlement) (*bill.PaymentDetails, error) {
 			pymt.Advances = append(pymt.Advances, a)
 		}
 	} else if stlm.Summary.TotalPrepaidAmount != "" {
-		// Fake an advanced payment so the totals will be re-calculated correclty
+		// Fake an advanced payment so the totals will be re-calculated correctly
 		amt, err := num.AmountFromString(stlm.Summary.TotalPrepaidAmount)
 		if err != nil {
 			return nil, err
@@ -73,6 +73,13 @@ func goblNewPaymentDetails(stlm *Settlement) (*bill.PaymentDetails, error) {
 			Amount: amt,
 		}
 		pymt.Advances = append(pymt.Advances, a)
+	}
+
+	if pymt.Payee == nil &&
+		pymt.Terms == nil &&
+		pymt.Instructions == nil &&
+		len(pymt.Advances) == 0 {
+		return nil, nil
 	}
 
 	return pymt, nil
@@ -112,6 +119,15 @@ func goblNewTerms(settlement *Settlement) (*pay.Terms, error) {
 		}
 	}
 	terms.DueDates = dates
+
+	if len(terms.DueDates) == 0 &&
+		terms.Notes == "" &&
+		terms.Key == "" &&
+		terms.Detail == "" &&
+		len(terms.Ext) == 0 {
+		return nil, nil
+	}
+
 	return terms, nil
 }
 

--- a/test/data/parse/out/CII_business_example_01.json
+++ b/test/data/parse/out/CII_business_example_01.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "c7e84d11233f8d557d44a8c0ec042508a1c31ad9d0bc4a10b852f5f433772f27"
+			"val": "17a3ab89b9d8e3af06c3de77f2ca9e03cd226d2df9051a52a612c23074d9c656"
 		}
 	},
 	"doc": {
@@ -96,7 +96,7 @@
 				"quantity": "1.000",
 				"item": {
 					"ref": "870",
-					"name": "zzgl. ",
+					"name": "zzgl.",
 					"price": "1.5000",
 					"unit": "one"
 				},

--- a/test/data/parse/out/CII_example1.json
+++ b/test/data/parse/out/CII_example1.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "67a0fb08e655a7861968b17e29dd4fb48b354f28bba5e9ac5e60fb8d6d3a4fbc"
+			"val": "9f86f899846c52e51642b1b90177ab3d038bf0c32b1655807af1a581f342454b"
 		}
 	},
 	"doc": {
@@ -131,7 +131,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "666955",
-					"name": "KOFFIE BLIK 3,5KG SNELF ",
+					"name": "KOFFIE BLIK 3,5KG SNELF",
 					"price": "35.00",
 					"unit": "piece"
 				},
@@ -149,7 +149,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "664871",
-					"name": "KOFFIE 3.5 KG BLIK STAND ",
+					"name": "KOFFIE 3.5 KG BLIK STAND",
 					"price": "35.00",
 					"unit": "piece"
 				},
@@ -185,7 +185,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "350258",
-					"name": "1 KG UL BLOKJES ",
+					"name": "1 KG UL BLOKJES",
 					"price": "1.55",
 					"unit": "piece"
 				},
@@ -203,7 +203,7 @@
 				"quantity": "3",
 				"item": {
 					"ref": "999998",
-					"name": "BLOCKNOTE A5 ",
+					"name": "BLOCKNOTE A5",
 					"price": "4.79",
 					"unit": "piece"
 				},
@@ -257,7 +257,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "740828",
-					"name": "TR KL PAKJES APPELSAP ",
+					"name": "TR KL PAKJES APPELSAP",
 					"price": "9.95",
 					"unit": "piece"
 				},
@@ -275,7 +275,7 @@
 				"quantity": "2",
 				"item": {
 					"ref": "740827",
-					"name": "PK CHOCOLADEMELK ",
+					"name": "PK CHOCOLADEMELK",
 					"price": "1.65",
 					"unit": "piece"
 				},
@@ -293,7 +293,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "999996",
-					"name": "KRAT BIER ",
+					"name": "KRAT BIER",
 					"price": "10.80",
 					"unit": "piece"
 				},
@@ -311,7 +311,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "999995",
-					"name": "STATIEGELD ",
+					"name": "STATIEGELD",
 					"price": "3.90",
 					"unit": "piece"
 				},
@@ -329,7 +329,7 @@
 				"quantity": "2",
 				"item": {
 					"ref": "102172",
-					"name": "BLEEK 3 X 750 ML ",
+					"name": "BLEEK 3 X 750 ML",
 					"price": "3.80",
 					"unit": "piece"
 				},
@@ -347,7 +347,7 @@
 				"quantity": "2",
 				"item": {
 					"ref": "999994",
-					"name": "WC PAPIER ",
+					"name": "WC PAPIER",
 					"price": "4.67",
 					"unit": "piece"
 				},
@@ -365,7 +365,7 @@
 				"quantity": "1",
 				"item": {
 					"ref": "999993",
-					"name": "BALPENNEN 50 ST BLAUW ",
+					"name": "BALPENNEN 50 ST BLAUW",
 					"price": "18.63",
 					"unit": "piece"
 				},
@@ -383,7 +383,7 @@
 				"quantity": "6",
 				"item": {
 					"ref": "999992",
-					"name": "EM FRITUURVET ",
+					"name": "EM FRITUURVET",
 					"price": "17.02",
 					"unit": "piece"
 				},
@@ -401,7 +401,7 @@
 				"quantity": "6",
 				"item": {
 					"ref": "175137",
-					"name": "FRITUUR VET 10 KG RETOUR ",
+					"name": "FRITUUR VET 10 KG RETOUR",
 					"price": "18.33",
 					"unit": "piece"
 				},

--- a/test/data/parse/out/zugferd-1.json
+++ b/test/data/parse/out/zugferd-1.json
@@ -1,0 +1,293 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "0617fcd7a086396f2eb925a2d3106a5366a6724fb50edf22dbfe50884d474054"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DE",
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"code": "471102",
+		"issue_date": "2018-06-05",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Lieferant GmbH",
+			"tax_id": {
+				"country": "DE",
+				"code": "123456789"
+			},
+			"identities": [
+				{
+					"country": "DE",
+					"code": "201/113/40209"
+				},
+				{
+					"code": "4000001123452",
+					"ext": {
+						"iso-scheme-id": "0088"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"street": "Lieferantenstraße 20",
+					"locality": "München",
+					"code": "80333",
+					"country": "DE"
+				}
+			]
+		},
+		"customer": {
+			"name": "Kunden AG Mitte",
+			"addresses": [
+				{
+					"street": "Kundenstraße 15",
+					"locality": "Frankfurt",
+					"code": "69876",
+					"country": "DE"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "3.0000",
+				"item": {
+					"ref": "KR3M",
+					"name": "Kunstrasen grün 3m breit",
+					"identities": [
+						{
+							"code": ""
+						},
+						{
+							"code": "4012345001235",
+							"ext": {
+								"iso-scheme-id": "0160"
+							}
+						}
+					],
+					"description": "300cm x 100 cm",
+					"price": "3.3333",
+					"unit": "m2"
+				},
+				"sum": "9.9999",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "19.00%"
+					}
+				],
+				"total": "9.9999",
+				"notes": [
+					{
+						"text": "Wir erlauben uns Ihnen folgende Positionen aus der Lieferung Nr. 2018-51112 in Rechnung zu stellen:"
+					}
+				]
+			},
+			{
+				"i": 2,
+				"quantity": "5.0000",
+				"item": {
+					"ref": "SFK5",
+					"name": "Schweinesteak",
+					"identities": [
+						{
+							"code": ""
+						},
+						{
+							"code": "4000050986428",
+							"ext": {
+								"iso-scheme-id": "0160"
+							}
+						}
+					],
+					"description": "aus Deutschland",
+					"price": "5.5000",
+					"unit": "kg"
+				},
+				"sum": "27.5000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "7.00%"
+					}
+				],
+				"total": "27.5000"
+			},
+			{
+				"i": 3,
+				"quantity": "20.0000",
+				"item": {
+					"ref": "GTRWA5",
+					"name": "Mineralwasser Medium 12 x 1,0l PET",
+					"identities": [
+						{
+							"code": ""
+						},
+						{
+							"code": "4000001234561",
+							"ext": {
+								"iso-scheme-id": "0160"
+							}
+						}
+					],
+					"price": "5.4900",
+					"unit": "piece"
+				},
+				"sum": "109.8000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "7.00%"
+					}
+				],
+				"total": "109.8000"
+			},
+			{
+				"i": 4,
+				"quantity": "20.0000",
+				"item": {
+					"ref": "PFA5",
+					"name": "Pfand",
+					"identities": [
+						{
+							"code": ""
+						},
+						{
+							"code": "4000001234578",
+							"ext": {
+								"iso-scheme-id": "0160"
+							}
+						}
+					],
+					"price": "2.7700",
+					"unit": "one"
+				},
+				"sum": "55.4000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "19.00%"
+					}
+				],
+				"total": "55.4000"
+			}
+		],
+		"discounts": [
+			{
+				"i": 1,
+				"reason": "Sondernachlass",
+				"base": "10.00",
+				"amount": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "19.00%"
+					}
+				]
+			},
+			{
+				"i": 2,
+				"reason": "Sondernachlass",
+				"base": "137.30",
+				"amount": "13.73",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "7.00%"
+					}
+				]
+			}
+		],
+		"charges": [
+			{
+				"i": 1,
+				"reason": "Versandkosten",
+				"base": "137.30",
+				"amount": "5.80",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "7.00%"
+					}
+				]
+			}
+		],
+		"ordering": {
+			"purchases": [
+				{
+					"code": "2013-471331"
+				}
+			]
+		},
+		"payment": {
+			"terms": {
+				"detail": "Zahlbar innerhalb 30 Tagen netto bis 04.07.2018, 3% Skonto innerhalb 10 Tagen bis 15.06.2018"
+			},
+			"advances": [
+				{
+					"description": "",
+					"amount": "50.00"
+				}
+			]
+		},
+		"delivery": {
+			"date": "2018-06-03"
+		},
+		"totals": {
+			"sum": "202.70",
+			"discount": "14.73",
+			"charge": "5.80",
+			"total": "193.77",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"base": "64.40",
+								"percent": "19.00%",
+								"amount": "12.24"
+							},
+							{
+								"base": "129.37",
+								"percent": "7.00%",
+								"amount": "9.06"
+							}
+						],
+						"amount": "21.29"
+					}
+				],
+				"sum": "21.29"
+			},
+			"tax": "21.29",
+			"total_with_tax": "215.06",
+			"payable": "215.06",
+			"advance": "50.00",
+			"due": "165.06"
+		},
+		"notes": [
+			{
+				"text": "\nRechnung gemäß Bestellung Nr. 2018-471331 vom 01.03.2018.\n\n      "
+			},
+			{
+				"code": "AAK",
+				"text": "\nEs bestehen Rabatt- und Bonusvereinbarungen.\n\n      "
+			},
+			{
+				"code": "REG",
+				"text": "Lieferant GmbH\nLieferantenstraße 20\n80333 München\nDeutschland\nGeschäftsführer: Hans Muster\nHandelsregisternummer: H A 123\n\n      "
+			}
+		]
+	}
+}

--- a/test/data/parse/zugferd-1.xml
+++ b/test/data/parse/zugferd-1.xml
@@ -1,0 +1,377 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte
+ZUGFeRD Datenformat Version 2.3.1, 15.11.2024
+Beispiel Version 15.11.2024
+
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter
+Technologien („ZUGFeRD Datenformat“).
+
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht
+diskriminierenden Bedingungen an.
+
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung
+abrufbar unter www.ferd-net.de.
+
+Im Einzelnen schließt die Nutzungsgewährung ein:
+=====================================
+
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein.
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung,
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige
+Anwendungen und Dienste.
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden.
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares,
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit
+anderen Produkten einzuräumen.
+
+Die Lizenz wird kostenfrei zur Verfügung gestellt.
+
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten,
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete,
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+
+ <!--Right of use
+ZUGFeRD Data format version 2.3.1, November 15th, 2024
+
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised
+technologies ("ZUGFeRD data format").
+
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non
+discriminatory conditions.
+
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version
+available at www.ferd-net.de.
+
+In detail, the grant of use includes
+=====================================
+
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective
+valid and accepted version (www.ferd-net.de).
+The license includes an irrevocable right of use including the right of further development,
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or
+other use of the ZUGFeRD data format for hardware and/or software products and other
+applications and services.
+This license does not include the essential patents of the members of FeRD. The essential patents are patents
+and patent applications worldwide which contain one or more claims that are
+necessary claims. Necessary claims are only those claims of the essential patents which are
+the implementation of the ZUGFeRD data format would necessarily be violated.
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable,
+irrevocable right of use including the right of further development, further processing and connection with
+other products.
+
+The license is provided free of charge.
+
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs
+damages, losses or liabilities in connection with an interruption of business, nor for concrete,
+incidental, indirect, punitive or consequential damages, even if the possibility of
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>471102</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20180605</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>
+Rechnung gemäß Bestellung Nr. 2018-471331 vom 01.03.2018.
+
+      </ram:Content>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>
+Es bestehen Rabatt- und Bonusvereinbarungen.
+
+      </ram:Content>
+      <ram:SubjectCode>AAK</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Lieferant GmbH
+Lieferantenstraße 20
+80333 München
+Deutschland
+Geschäftsführer: Hans Muster
+Handelsregisternummer: H A 123
+
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+		  <ram:IncludedNote>
+          <ram:Content>Wir erlauben uns Ihnen folgende Positionen aus der Lieferung Nr. 2018-51112 in Rechnung zu stellen:</ram:Content>
+        </ram:IncludedNote>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4012345001235</ram:GlobalID>
+        <ram:SellerAssignedID>KR3M</ram:SellerAssignedID>
+        <ram:BuyerAssignedID/>
+        <ram:Name>Kunstrasen grün 3m breit</ram:Name>
+        <ram:Description>300cm x 100 cm</ram:Description>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>4.0000</ram:ChargeAmount>
+          <ram:AppliedTradeAllowanceCharge>
+			<ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:ActualAmount>0.6667</ram:ActualAmount>
+          </ram:AppliedTradeAllowanceCharge>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>3.3333</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="MTK">3.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>10.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000050986428</ram:GlobalID>
+        <ram:SellerAssignedID>SFK5</ram:SellerAssignedID>
+        <ram:BuyerAssignedID/>
+        <ram:Name>Schweinesteak</ram:Name>
+        <ram:Description>aus Deutschland</ram:Description>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="KGM">5.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>27.50</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>3</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000001234561</ram:GlobalID>
+        <ram:SellerAssignedID>GTRWA5</ram:SellerAssignedID>
+        <ram:BuyerAssignedID/>
+        <ram:Name>Mineralwasser Medium 12 x 1,0l PET
+        </ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>5.4900</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.4900</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">20.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>109.80</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>4</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000001234578</ram:GlobalID>
+        <ram:SellerAssignedID>PFA5</ram:SellerAssignedID>
+        <ram:BuyerAssignedID/>
+        <ram:Name>Pfand</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>2.7700</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>2.7700</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">20.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>55.40</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:GlobalID schemeID="0088">4000001123452</ram:GlobalID>
+        <ram:Name>Lieferant GmbH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>80333</ram:PostcodeCode>
+          <ram:LineOne>Lieferantenstraße 20</ram:LineOne>
+          <ram:CityName>München</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">201/113/40209</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>GE2020211</ram:ID>
+        <ram:Name>Kunden AG Mitte</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>69876</ram:PostcodeCode>
+          <ram:LineOne>Kundenstraße 15</ram:LineOne>
+          <ram:CityName>Frankfurt</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+      <ram:BuyerOrderReferencedDocument>
+        <ram:IssuerAssignedID>2013-471331</ram:IssuerAssignedID>
+      </ram:BuyerOrderReferencedDocument>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180603</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>9.06</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>129.37</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>12.24</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>64.40</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:BasisAmount>10.00</ram:BasisAmount>
+        <ram:ActualAmount>1.00</ram:ActualAmount>
+        <ram:Reason>Sondernachlass</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:BasisAmount>137.30</ram:BasisAmount>
+        <ram:ActualAmount>13.73</ram:ActualAmount>
+        <ram:Reason>Sondernachlass</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+
+	  <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>true</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:BasisAmount>137.30</ram:BasisAmount>
+        <ram:ActualAmount>5.80</ram:ActualAmount>
+        <ram:Reason>Versandkosten</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+
+
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>Zahlbar innerhalb 30 Tagen netto bis 04.07.2018, 3% Skonto innerhalb 10 Tagen bis 15.06.2018</ram:Description>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>202.70</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>5.80</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>14.73</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>193.77</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">21.30</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>215.07</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>50.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>165.07</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/utils.go
+++ b/utils.go
@@ -21,13 +21,6 @@ func (d *Invoice) Bytes() ([]byte, error) {
 	return append([]byte(xml.Header), bytes...), nil
 }
 
-// HasPayment returns true if the settlement has payment. Helper function for CtoG readability
-func (ah *Settlement) HasPayment() bool {
-	return ah.Payee != nil ||
-		(len(ah.PaymentTerms) > 0 && ah.PaymentTerms[0].DueDate != nil) ||
-		(len(ah.PaymentMeans) > 0 && ah.PaymentMeans[0].TypeCode != "1")
-}
-
 func documentDate(date *cal.Date) *Date {
 	if date == nil {
 		return nil


### PR DESCRIPTION
* Fixing an issue with a document that was lacking other payment details but did have advances.
* Removing whitespace from a few names and descriptions.