### PR TITLE
Remove default buyer reference

### DIFF
--- a/agreement.go
+++ b/agreement.go
@@ -47,8 +47,6 @@ func (out *Invoice) addAgreement(inv *bill.Invoice) error {
 	agmt := out.Transaction.Agreement
 	if inv.Ordering != nil && inv.Ordering.Code != "" {
 		agmt.BuyerReference = inv.Ordering.Code.String()
-	} else {
-		agmt.BuyerReference = defaultBuyerReference
 	}
 	if supplier := inv.Supplier; supplier != nil {
 		agmt.Seller = newParty(supplier)

--- a/test/data/convert/choruspro/out/invoice-de-fr-choruspro.xml
+++ b/test/data/convert/choruspro/out/invoice-de-fr-choruspro.xml
@@ -47,7 +47,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One Inc.</ram:Name>
         <ram:SpecifiedLegalOrganization>

--- a/test/data/convert/choruspro/out/invoice-fr-fr-choruspro.xml
+++ b/test/data/convert/choruspro/out/invoice-fr-fr-choruspro.xml
@@ -47,7 +47,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One Inc.</ram:Name>
         <ram:SpecifiedLegalOrganization>

--- a/test/data/convert/en16931/out/invoice-exempt.xml
+++ b/test/data/convert/en16931/out/invoice-exempt.xml
@@ -41,7 +41,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>CYBERDYNE IT GmbH</ram:Name>
         <ram:DefinedTradeContact>

--- a/test/data/convert/en16931/out/invoice-minimal.xml
+++ b/test/data/convert/en16931/out/invoice-minimal.xml
@@ -40,7 +40,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>

--- a/test/data/convert/facturx/out/invoice-exempt.xml
+++ b/test/data/convert/facturx/out/invoice-exempt.xml
@@ -41,7 +41,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>CYBERDYNE IT GmbH</ram:Name>
         <ram:DefinedTradeContact>

--- a/test/data/convert/facturx/out/invoice-minimal.xml
+++ b/test/data/convert/facturx/out/invoice-minimal.xml
@@ -40,7 +40,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>

--- a/test/data/convert/peppol/invoice-minimal.json
+++ b/test/data/convert/peppol/invoice-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2c64fff4b6d1a502acf7de42e1f61784e822e48cb179f23b1da9fec8394fb83b"
+			"val": "305af6be4f2b7d2e8972c81f5759d71f3a405ccb80507c41df96ae5cc9bddcb6"
 		}
 	},
 	"doc": {
@@ -102,6 +102,13 @@
 				"total": "1800.00"
 			}
 		],
+		"ordering": {
+			"purchases": [
+				{
+					"code": "E2025003242"
+				}
+			]
+		},
 		"payment": {
 			"terms": {
 				"detail": "lorem ipsum"

--- a/test/data/convert/peppol/out/invoice-minimal.xml
+++ b/test/data/convert/peppol/out/invoice-minimal.xml
@@ -43,7 +43,6 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>
@@ -84,6 +83,9 @@
           <ram:ID schemeID="VA">DE282741168</ram:ID>
         </ram:SpecifiedTaxRegistration>
       </ram:BuyerTradeParty>
+      <ram:BuyerOrderReferencedDocument>
+        <ram:IssuerAssignedID>E2025003242</ram:IssuerAssignedID>
+      </ram:BuyerOrderReferencedDocument>
     </ram:ApplicableHeaderTradeAgreement>
     <ram:ApplicableHeaderTradeDelivery></ram:ApplicableHeaderTradeDelivery>
     <ram:ApplicableHeaderTradeSettlement>

--- a/test/data/convert/xrechnung/invoice-de-de.json
+++ b/test/data/convert/xrechnung/invoice-de-de.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "b3b2f4decab1f69c49803bb73d50ca7a032e66df8d18a66a7cf27e9a221e330e"
+			"val": "1805a25b104248e6c0d628df75c84e711ea9f1d2c6ed8bcd65877f5b18b94295"
 		}
 	},
 	"doc": {
@@ -131,6 +131,9 @@
 				"total": "1620.00"
 			}
 		],
+		"ordering": {
+			"code": "E2025003242"
+		},
 		"payment": {
 			"instructions": {
 				"key": "credit-transfer+sepa",

--- a/test/data/convert/xrechnung/invoice-de-es-b2b.json
+++ b/test/data/convert/xrechnung/invoice-de-es-b2b.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "3e251dd2b86eda283aa41c754e1233f70490312d321b0a7aa3f6ec5b119b7d03"
+			"val": "9c9c5598c6d1bee90ae4089136a8a14bafffd93449cfa4f217882cacf98e49b0"
 		}
 	},
 	"doc": {
@@ -125,6 +125,9 @@
 				"total": "1620.00"
 			}
 		],
+		"ordering": {
+			"code": "E2025003242"
+		},
 		"payment": {
 			"instructions": {
 				"key": "credit-transfer+sepa",

--- a/test/data/convert/xrechnung/out/invoice-de-de.xml
+++ b/test/data/convert/xrechnung/out/invoice-de-de.xml
@@ -50,7 +50,7 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
+      <ram:BuyerReference>E2025003242</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>

--- a/test/data/convert/xrechnung/out/invoice-de-es-b2b.xml
+++ b/test/data/convert/xrechnung/out/invoice-de-es-b2b.xml
@@ -53,7 +53,7 @@
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
-      <ram:BuyerReference>NA</ram:BuyerReference>
+      <ram:BuyerReference>E2025003242</ram:BuyerReference>
       <ram:SellerTradeParty>
         <ram:Name>Provide One GmbH</ram:Name>
         <ram:DefinedTradeContact>


### PR DESCRIPTION
This PR removes the default buyer reference. This has caused issues with Chorus Pro as it the system could not find a reference to NA. It was originally added as Xrechnung required this field but this validation has been added in https://github.com/invopop/gobl/pull/517.

My suggestion is to merge this PR but only update cii so that other apps using this library will maintain their current functionalities.