### PR TITLE
fix typo in Agreement/SpecifiedProcuringProject

### DIFF
--- a/agreement.go
+++ b/agreement.go
@@ -15,7 +15,7 @@ type Agreement struct {
 	Purchase           *IssuerID             `xml:"ram:BuyerOrderReferencedDocument,omitempty"`
 	Contract           *IssuerID             `xml:"ram:ContractReferencedDocument,omitempty"`
 	AdditionalDocument []*AdditionalDocument `xml:"ram:AdditionalReferencedDocument,omitempty"`
-	Project            *Project              `xml:"ram:SpecifiedProcurringProject,omitempty"`
+	Project            *Project              `xml:"ram:SpecifiedProcuringProject,omitempty"`
 }
 
 // Project defines common architecture of document reference fields in the CII standard


### PR DESCRIPTION
Apparently Factur-X/ZUGFeRD schemas define the tag using 'Procuring' with a single 'r', rather than 'Procurring'.

I became aware of this because I have a use case for which I would use this field.