### PR TITLE
feat(extended): emit bill.Line.Breakdown as EXTENDED-CTC-FR line hierarchy

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -132,7 +132,7 @@ func newInvoice(inv *bill.Invoice, context Context) (*Invoice, error) {
 func (out *Invoice) addTransaction(inv *bill.Invoice, ctx Context) error {
 	out.Transaction = new(Transaction)
 
-	if err := out.addLines(inv.Lines); err != nil {
+	if err := out.addLines(inv.Lines, ctx); err != nil {
 		return err
 	}
 	if err := out.addAgreement(inv, ctx); err != nil {

--- a/lines.go
+++ b/lines.go
@@ -1,11 +1,13 @@
 package cii
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/tax"
 )
 
 // Line defines the structure of the IncludedSupplyChainTradeLineItem in the CII standard
@@ -19,8 +21,15 @@ type Line struct {
 
 // LineDoc defines the structure of the AssociatedDocumentLineDocument in the CII standard
 type LineDoc struct {
-	ID   string  `xml:"ram:LineID"`
-	Note []*Note `xml:"ram:IncludedNote,omitempty"`
+	ID string `xml:"ram:LineID"`
+	// ParentLineID (BT-X-304 / EXT-FR-FE-162) references the LineID of the
+	// parent line in an EXTENDED-CTC-FR line hierarchy.
+	ParentLineID string `xml:"ram:ParentLineID,omitempty"`
+	// LineStatusReasonCode (BT-X-8 / EXT-FR-FE-163) carries the line subtype
+	// in a hierarchy: GROUP (aggregating header) or DETAIL (leaf). XSD order
+	// places it after the optional LineStatusCode, which we never emit.
+	LineStatusReasonCode string  `xml:"ram:LineStatusReasonCode,omitempty"`
+	Note                 []*Note `xml:"ram:IncludedNote,omitempty"`
 }
 
 // LineAgreement defines the structure of the SpecifiedLineTradeAgreement in the CII standard
@@ -113,15 +122,89 @@ type Summation struct {
 	Amount string `xml:"ram:LineTotalAmount"`
 }
 
-func (out *Invoice) addLines(lines []*bill.Line) error {
-	var Lines []*Line
+// Line subtype codes (BT-X-8 / EXT-FR-FE-163) for the EXTENDED-CTC-FR
+// line hierarchy.
+const (
+	lineSubtypeGroup  = "GROUP"
+	lineSubtypeDetail = "DETAIL"
+)
 
+func (out *Invoice) addLines(lines []*bill.Line, ctx Context) error {
+	// The EXTENDED-CTC-FR profile is the only CII context that supports a
+	// line hierarchy (parent/child via ParentLineID + subtype). For every
+	// other guideline a Breakdown is informational only and is not emitted,
+	// preserving the prior flat behaviour.
+	hierarchy := ctx.Is(ContextPeppolFranceFacturXV1)
+
+	var Lines []*Line
 	for _, l := range lines {
-		Lines = append(Lines, newLine(l))
+		if hierarchy && len(l.Breakdown) > 0 {
+			Lines = append(Lines, newHierarchyLines(l)...)
+			continue
+		}
+		if line := newLine(l); line != nil {
+			Lines = append(Lines, line)
+		}
 	}
 
 	out.Transaction.Lines = Lines
 	return nil
+}
+
+// newHierarchyLines maps a bill.Line carrying a Breakdown onto an
+// EXTENDED-CTC-FR line hierarchy: the line itself becomes a GROUP header
+// (aggregating, carries no VAT so it is excluded from the VAT breakdown
+// and the BT-106 sum) whose BT-131 equals the sum of its children, and
+// each SubLine becomes a DETAIL child carrying the parent line's VAT
+// category (SubLines have no taxes of their own) and pointing back via
+// ParentLineID. See BR-FREXT-06 (subtype required when a parent is set)
+// and BR-FREXT-08 (GROUP net = Σ children).
+func newHierarchyLines(l *bill.Line) []*Line {
+	group := newLine(l)
+	if group == nil {
+		return nil
+	}
+	group.LineDoc.LineStatusReasonCode = lineSubtypeGroup
+	if group.TradeSettlement != nil {
+		group.TradeSettlement.ApplicableTradeTax = nil
+	}
+
+	lines := []*Line{group}
+	parentID := group.LineDoc.ID
+	for i, sub := range l.Breakdown {
+		if sub == nil || sub.Item == nil {
+			continue
+		}
+		child := newLine(subLineAsLine(sub, l.Taxes, i+1))
+		if child == nil {
+			continue
+		}
+		child.LineDoc.ID = fmt.Sprintf("%s.%d", parentID, i+1)
+		child.LineDoc.ParentLineID = parentID
+		child.LineDoc.LineStatusReasonCode = lineSubtypeDetail
+		lines = append(lines, child)
+	}
+	return lines
+}
+
+// subLineAsLine adapts a bill.SubLine into a bill.Line so it can reuse
+// newLine. SubLines carry no taxes of their own, so the parent line's tax
+// set is inherited — the whole hierarchy shares one VAT category.
+func subLineAsLine(sub *bill.SubLine, taxes tax.Set, index int) *bill.Line {
+	return &bill.Line{
+		Index:      index,
+		Quantity:   sub.Quantity,
+		Item:       sub.Item,
+		Identifier: sub.Identifier,
+		Period:     sub.Period,
+		Order:      sub.Order,
+		Cost:       sub.Cost,
+		Discounts:  sub.Discounts,
+		Charges:    sub.Charges,
+		Notes:      sub.Notes,
+		Taxes:      taxes,
+		Total:      sub.Total,
+	}
 }
 
 func newLine(l *bill.Line) *Line {

--- a/lines.go
+++ b/lines.go
@@ -239,6 +239,18 @@ func newLine(l *bill.Line) *Line {
 		lineItem.Product.Description = &it.Description
 	}
 
+	// BT-155: Seller's item identifier
+	if it.Ref != "" {
+		ref := it.Ref.String()
+		lineItem.Product.SellerAssignedID = &ref
+	}
+
+	// BT-159: Item country of origin
+	if it.Origin != "" {
+		origin := string(it.Origin)
+		lineItem.Product.Origin = &origin
+	}
+
 	if len(l.Notes) > 0 {
 		var notes []*Note
 		for _, n := range l.Notes {

--- a/test/data/convert/peppol-france-facturx/invoice-hierarchy.json
+++ b/test/data/convert/peppol-france-facturx/invoice-hierarchy.json
@@ -1,0 +1,228 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "39c74049e2bf2c8d8c25116899e5a6403db85cecdac82301491e99f40b279171"
+		},
+		"from": "iso6523-actorid-upis::0225:356000000",
+		"to": "iso6523-actorid-upis::0225:732829320"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "FR",
+		"$addons": [
+			"eu-en16931-v2017",
+			"fr-ctc-flow2-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"code": "FAC-2024-002",
+		"issue_date": "2024-06-13",
+		"currency": "EUR",
+		"tax": {
+			"rounding": "currency",
+			"ext": {
+				"fr-ctc-billing-mode": "S1",
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Supplier SARL",
+			"tax_id": {
+				"country": "FR",
+				"code": "39356000000"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"type": "SIREN",
+					"code": "356000000",
+					"ext": {
+						"iso-scheme-id": "0002"
+					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0225:356000000"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0225",
+					"code": "356000000"
+				}
+			],
+			"addresses": [
+				{
+					"street": "1 Rue",
+					"locality": "Paris",
+					"code": "75001",
+					"country": "FR"
+				}
+			]
+		},
+		"customer": {
+			"name": "Customer SAS",
+			"tax_id": {
+				"country": "FR",
+				"code": "44732829320"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"type": "SIREN",
+					"code": "732829320",
+					"ext": {
+						"iso-scheme-id": "0002"
+					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0225:732829320"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0225",
+					"code": "732829320"
+				}
+			],
+			"addresses": [
+				{
+					"street": "1 Rue",
+					"locality": "Paris",
+					"code": "75001",
+					"country": "FR"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Consulting package",
+					"currency": "EUR",
+					"price": "1000.00",
+					"unit": "one"
+				},
+				"breakdown": [
+					{
+						"i": 1,
+						"quantity": "6",
+						"item": {
+							"name": "Junior consultant",
+							"price": "100.00",
+							"unit": "h"
+						},
+						"sum": "600.00",
+						"total": "600.00"
+					},
+					{
+						"i": 2,
+						"quantity": "4",
+						"item": {
+							"name": "Senior consultant",
+							"price": "100.00",
+							"unit": "h"
+						},
+						"sum": "400.00",
+						"total": "400.00"
+					}
+				],
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "20%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2024-07-13",
+						"amount": "1200.00"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "FR7630006000011234567890189",
+						"name": "Supplier SARL"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1000.00",
+								"percent": "20%",
+								"amount": "200.00"
+							}
+						],
+						"amount": "200.00"
+					}
+				],
+				"sum": "200.00"
+			},
+			"tax": "200.00",
+			"total_with_tax": "1200.00",
+			"payable": "1200.00"
+		},
+		"notes": [
+			{
+				"key": "payment",
+				"text": "Conditions.",
+				"ext": {
+					"untdid-text-subject": "PMT"
+				}
+			},
+			{
+				"key": "payment-method",
+				"text": "Penalties.",
+				"ext": {
+					"untdid-text-subject": "PMD"
+				}
+			},
+			{
+				"key": "payment-term",
+				"text": "No early discount.",
+				"ext": {
+					"untdid-text-subject": "AAB"
+				}
+			}
+		]
+	}
+}

--- a/test/data/convert/peppol-france-facturx/out/invoice-hierarchy.xml
+++ b/test/data/convert/peppol-france-facturx/out/invoice-hierarchy.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:BusinessProcessSpecifiedDocumentContextParameter>
+      <ram:ID>S1</ram:ID>
+    </ram:BusinessProcessSpecifiedDocumentContextParameter>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>FAC-2024-002</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20240613</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>Conditions.</ram:Content>
+      <ram:SubjectCode>PMT</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Penalties.</ram:Content>
+      <ram:SubjectCode>PMD</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>No early discount.</ram:Content>
+      <ram:SubjectCode>AAB</ram:SubjectCode>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+        <ram:LineStatusReasonCode>GROUP</ram:LineStatusReasonCode>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Consulting package</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>1000.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">1</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>1000.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1.1</ram:LineID>
+        <ram:ParentLineID>1</ram:ParentLineID>
+        <ram:LineStatusReasonCode>DETAIL</ram:LineStatusReasonCode>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Junior consultant</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="HUR">6</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>600.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1.2</ram:LineID>
+        <ram:ParentLineID>1</ram:ParentLineID>
+        <ram:LineStatusReasonCode>DETAIL</ram:LineStatusReasonCode>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Senior consultant</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="HUR">4</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>400.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:Name>Supplier SARL</ram:Name>
+        <ram:SpecifiedLegalOrganization>
+          <ram:ID schemeID="0002">356000000</ram:ID>
+        </ram:SpecifiedLegalOrganization>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>75001</ram:PostcodeCode>
+          <ram:LineOne>1 Rue</ram:LineOne>
+          <ram:CityName>Paris</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="0225">356000000</ram:URIID>
+        </ram:URIUniversalCommunication>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">FR39356000000</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:Name>Customer SAS</ram:Name>
+        <ram:SpecifiedLegalOrganization>
+          <ram:ID schemeID="0002">732829320</ram:ID>
+        </ram:SpecifiedLegalOrganization>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>75001</ram:PostcodeCode>
+          <ram:LineOne>1 Rue</ram:LineOne>
+          <ram:CityName>Paris</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="0225">732829320</ram:URIID>
+        </ram:URIUniversalCommunication>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">FR44732829320</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery></ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+        <ram:TypeCode>30</ram:TypeCode>
+        <ram:PayeePartyCreditorFinancialAccount>
+          <ram:IBANID>FR7630006000011234567890189</ram:IBANID>
+        </ram:PayeePartyCreditorFinancialAccount>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>200.00</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>1000.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>20</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:DueDateDateTime>
+          <udt:DateTimeString format="102">20240713</udt:DateTimeString>
+        </ram:DueDateDateTime>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>1000.00</ram:LineTotalAmount>
+        <ram:TaxBasisTotalAmount>1000.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">200.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>1200.00</ram:GrandTotalAmount>
+        <ram:DuePayableAmount>1200.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
## What

Teaches `gobl.cii` to emit a line hierarchy for the **EXTENDED-CTC-FR** profile. Previously `addLines` emitted one flat `IncludedSupplyChainTradeLineItem` per top-level line and ignored `bill.Line.Breakdown` entirely — so the extended line hierarchy (EXT-FR-FE-162/163) could not be produced.

Now, when the context is `ContextPeppolFranceFacturXV1` and a line has a `Breakdown`:

- the line becomes a **GROUP** header line, and each `SubLine` a **DETAIL** child, in `ram:AssociatedDocumentLineDocument`:
  - `ParentLineID` (BT-X-304 / **EXT-FR-FE-162**) → parent `LineID`
  - `LineStatusReasonCode` (BT-X-8 / **EXT-FR-FE-163**) = `GROUP` | `DETAIL`
  - the **GROUP** line carries **no `ApplicableTradeTax`** (excluded from the VAT breakdown and the BT-106 line sum) with `BT-131 = Σ children` (`BR-FREXT-08`)
  - **DETAIL** children inherit the parent line's single VAT category (GOBL `SubLine`s carry no taxes of their own); `SubLine.Total` sums to `Line.Total`, so the header and per-category VAT bases reconcile automatically

Every other guideline keeps the prior flat behaviour (a `Breakdown` is informational and not emitted).

## How it was derived

The exact CII representation and the GROUP/DETAIL summation rules aren't documented for us — they were **reverse-engineered empirically** with four `ValidateXml` probes against the `fr.ctc:extended-cii:1.3.1` schematron in phive (`EXTENDED-CTC-FR-CII-V1.3.1` + `BR-FR-Flux2-CII-V1.3.1`), keying on `BR-FREXT-06` (subtype required when a parent is set) and `BR-FREXT-08` (GROUP net = Σ children).

## Verification

New fixture `peppol-france-facturx/invoice-hierarchy.json` (a line broken into two sub-lines). Its generated golden validates **clean** against `fr.ctc:extended-cii:1.3.1`: XSD + both schematron layers, **0 errors, 0 warnings**. Full `go test ./...` green.

## Note / follow-up

This is the **generation** direction only. The parse path doesn't yet reconstruct `Breakdown` from `ParentLineID`/subtype (a CII hierarchy round-trips to flat GOBL lines) — separate follow-up if round-trip fidelity is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)