### PR TITLE
Omit empty FormattedIssueDateTime for dateless preceding ref

### DIFF
--- a/settlement.go
+++ b/settlement.go
@@ -159,14 +159,16 @@ func newSettlement(inv *bill.Invoice, ctx Context) (*Settlement, error) {
 
 	if len(inv.Preceding) > 0 {
 		pre := inv.Preceding[0]
-		stlm.ReferencedDocument = []*ReferencedDocument{
-			{
-				IssuerAssignedID: invoiceNumber(pre.Series, pre.Code),
-				IssueDate: &FormattedIssueDate{
-					DateFormat: documentDate(pre.IssueDate),
-				},
-			},
+		rd := &ReferencedDocument{
+			IssuerAssignedID: invoiceNumber(pre.Series, pre.Code),
 		}
+		// IssueDate (BT-26) is optional; only emit FormattedIssueDateTime when the
+		// preceding reference actually has a date, otherwise it renders as an empty
+		// element and fails the CII XSD.
+		if d := documentDate(pre.IssueDate); d != nil {
+			rd.IssueDate = &FormattedIssueDate{DateFormat: d}
+		}
+		stlm.ReferencedDocument = []*ReferencedDocument{rd}
 	}
 	if inv.Payment != nil && inv.Payment.Payee != nil {
 		stlm.Payee = newPayee(inv.Payment.Payee, ctx)

--- a/settlement_test.go
+++ b/settlement_test.go
@@ -39,6 +39,24 @@ func TestNewSettlement(t *testing.T) {
 		assert.Equal(t, "102", doc.Transaction.Settlement.ReferencedDocument[0].IssueDate.DateFormat.Format)
 	})
 
+	t.Run("correction without preceding date", func(t *testing.T) {
+		// A preceding reference (BT-25) without an issue date (BT-26, optional) is
+		// valid GOBL; the FormattedIssueDateTime element must be omitted rather than
+		// rendered empty, which would fail the CII XSD.
+		env := loadEnvelope(t, "en16931/correction-invoice.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		require.NotEmpty(t, inv.Preceding)
+		inv.Preceding[0].IssueDate = nil
+
+		doc, err := cii.ConvertInvoice(env)
+		require.NoError(t, err)
+
+		rd := doc.Transaction.Settlement.ReferencedDocument[0]
+		assert.Equal(t, "SAMPLE-001", rd.IssuerAssignedID)
+		assert.Nil(t, rd.IssueDate, "empty FormattedIssueDateTime must be omitted, not rendered empty")
+	})
+
 	t.Run("invoice-complete.json", func(t *testing.T) {
 		doc, err := newInvoiceFrom(t, "en16931/invoice-complete.json")
 		require.NoError(t, err)


### PR DESCRIPTION
## Problem
A CII invoice with a `preceding` reference that has **no issue date** produced invalid XML:
```xml
<ram:InvoiceReferencedDocument>
  <ram:IssuerAssignedID>755</ram:IssuerAssignedID>
  <ram:FormattedIssueDateTime></ram:FormattedIssueDateTime>   <!-- empty -->
</ram:InvoiceReferencedDocument>
```
The CII XSD rejects it (`cvc-complex-type.2.4.b`): `FormattedIssueDateTime` requires a `qdt:DateTimeString` child. Confirmed against `eu.cen.en16931:cii:1.3.13` (XSD invalid → schematron skipped).