### PR TITLE
cdar: MDT-91 from untdid-document-type extension

### DIFF
--- a/cdar_mdt129_test.go
+++ b/cdar_mdt129_test.go
@@ -1,0 +1,117 @@
+package cii_test
+
+import (
+	"testing"
+	"time"
+
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl.fr.ctc/addon/flow6"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mdt129Issuer converts a 212 receipt referencing an invoice of the given type
+// (with an optional explicit issuer identity on the doc ref) and returns the
+// referenced-invoice issuer SIREN the CDV carries in MDT-129.
+func mdt129Issuer(t *testing.T, docType cbc.Code, docIDs []*org.Identity) string {
+	t.Helper()
+	docDate := cal.MakeDate(2025, time.July, 1)
+	pct := num.MakePercentage(20, 2)
+	pmt := &bill.Payment{
+		Type:      bill.PaymentTypeReceipt,
+		Code:      "PAY-212",
+		IssueDate: cal.MakeDate(2025, time.July, 2),
+		Currency:  currency.EUR,
+		Ext: tax.ExtensionsOf(cbc.CodeMap{
+			flow6.ExtKeyStatus:    "212",
+			flow6.ExtKeyCondition: flow6.ConditionAmountReceived,
+		}),
+		Supplier: testSIRENParty("VENDEUR", "100000009"),
+		Customer: testSIRENParty("ACHETEUR", "200000008"),
+		Lines: []*bill.PaymentLine{{
+			Document: &org.DocumentRef{
+				Code:       "F202500003",
+				IssueDate:  &docDate,
+				Ext:        tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyDocumentType: docType}),
+				Identities: docIDs,
+			},
+			Amount: num.MakeAmount(50000, 2),
+			Tax: &tax.Total{Categories: []*tax.CategoryTotal{{
+				Code:   tax.CategoryVAT,
+				Rates:  []*tax.RateTotal{{Base: num.MakeAmount(41667, 2), Percent: &pct, Amount: num.MakeAmount(8333, 2)}},
+				Amount: num.MakeAmount(8333, 2),
+			}}, Sum: num.MakeAmount(8333, 2)},
+		}},
+	}
+
+	cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+	require.NoError(t, err)
+	require.NotEmpty(t, cdar.AcknowledgementDocuments)
+	refs := cdar.AcknowledgementDocuments[0].ReferenceReferencedDocument
+	require.NotEmpty(t, refs)
+	require.NotNil(t, refs[0].IssuerTradeParty, "MDT-129 issuer party must be present")
+	require.NotEmpty(t, refs[0].IssuerTradeParty.GlobalIDs)
+	return refs[0].IssuerTradeParty.GlobalIDs[0].Value
+}
+
+// TestCDARReferencedIssuerMDT129 covers the referenced-invoice issuer (MDT-129)
+// derivation: seller by default, buyer for a self-billed reference, and an
+// explicit doc-ref identity overriding the role derivation entirely.
+func TestCDARReferencedIssuerMDT129(t *testing.T) {
+	t.Run("normal invoice (380): issuer is the seller", func(t *testing.T) {
+		assert.Equal(t, "100000009", mdt129Issuer(t, "380", nil))
+	})
+
+	t.Run("self-billed invoice (389): issuer is the buyer", func(t *testing.T) {
+		assert.Equal(t, "200000008", mdt129Issuer(t, "389", nil))
+	})
+
+	t.Run("self-billed credit note (261): issuer is the buyer", func(t *testing.T) {
+		assert.Equal(t, "200000008", mdt129Issuer(t, "261", nil))
+	})
+
+	t.Run("explicit doc-ref identity wins over role derivation", func(t *testing.T) {
+		// A parsed CDAR round-trips the true issuer onto the doc ref's
+		// identities; that identity is authoritative even when the type would
+		// otherwise derive a different party.
+		explicit := []*org.Identity{{
+			Code: "123456782",
+			Ext:  tax.ExtensionsOf(cbc.CodeMap{iso.ExtKeySchemeID: "0002"}),
+		}}
+		assert.Equal(t, "123456782", mdt129Issuer(t, "389", explicit))
+	})
+}
+
+// TestCDARPaymentVATRoundTrip confirms a 212 receipt's VAT breakdown (MDT-224)
+// survives the GOBL → CDAR → GOBL round-trip: the parse recovers the base, rate
+// and VAT amount from the gross-and-percentage characteristic.
+func TestCDARPaymentVATRoundTrip(t *testing.T) {
+	pmt := buildSyntheticPayment(t, num.Amount{})
+
+	cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+	require.NoError(t, err)
+	data, err := cdar.Bytes()
+	require.NoError(t, err)
+
+	out, err := cii.ParseCDARPayment(data)
+	require.NoError(t, err)
+	require.Len(t, out.Lines, 1)
+	require.NotNil(t, out.Lines[0].Tax, "212 VAT breakdown (MDT-224) must round-trip")
+	require.NotEmpty(t, out.Lines[0].Tax.Categories)
+
+	cat := out.Lines[0].Tax.Categories[0]
+	assert.Equal(t, tax.CategoryVAT, cat.Code)
+	require.NotEmpty(t, cat.Rates)
+	require.NotNil(t, cat.Rates[0].Percent)
+	assert.Equal(t, "416.67", cat.Rates[0].Base.String())
+	assert.Equal(t, "83.33", cat.Rates[0].Amount.String())
+}

--- a/cdar_mdt129_test.go
+++ b/cdar_mdt129_test.go
@@ -63,26 +63,26 @@ func mdt129Issuer(t *testing.T, docType cbc.Code, docIDs []*org.Identity) string
 	return refs[0].IssuerTradeParty.GlobalIDs[0].Value
 }
 
-// TestCDARReferencedIssuerMDT129 covers the referenced-invoice issuer (MDT-129)
-// derivation: seller by default, buyer for a self-billed reference, and an
-// explicit doc-ref identity overriding the role derivation entirely.
+// TestCDARReferencedIssuerMDT129 covers the referenced-invoice issuer (MDT-129):
+// the invoice supplier (seller), including for a self-billed reference — PPF
+// names the supplier as MDT-129 even for a self-billed extract (confirmed on
+// QUAL 2026-07-15) — with an explicit doc-ref identity overriding the default.
 func TestCDARReferencedIssuerMDT129(t *testing.T) {
-	t.Run("normal invoice (380): issuer is the seller", func(t *testing.T) {
+	t.Run("normal invoice (380): issuer is the supplier", func(t *testing.T) {
 		assert.Equal(t, "100000009", mdt129Issuer(t, "380", nil))
 	})
 
-	t.Run("self-billed invoice (389): issuer is the buyer", func(t *testing.T) {
-		assert.Equal(t, "200000008", mdt129Issuer(t, "389", nil))
+	t.Run("self-billed invoice (389): issuer is still the supplier", func(t *testing.T) {
+		assert.Equal(t, "100000009", mdt129Issuer(t, "389", nil))
 	})
 
-	t.Run("self-billed credit note (261): issuer is the buyer", func(t *testing.T) {
-		assert.Equal(t, "200000008", mdt129Issuer(t, "261", nil))
+	t.Run("self-billed credit note (261): issuer is still the supplier", func(t *testing.T) {
+		assert.Equal(t, "100000009", mdt129Issuer(t, "261", nil))
 	})
 
-	t.Run("explicit doc-ref identity wins over role derivation", func(t *testing.T) {
+	t.Run("explicit doc-ref identity wins over the supplier default", func(t *testing.T) {
 		// A parsed CDAR round-trips the true issuer onto the doc ref's
-		// identities; that identity is authoritative even when the type would
-		// otherwise derive a different party.
+		// identities; that identity is authoritative.
 		explicit := []*org.Identity{{
 			Code: "123456782",
 			Ext:  tax.ExtensionsOf(cbc.CodeMap{iso.ExtKeySchemeID: "0002"}),

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl.fr.ctc/addon/flow6"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
@@ -155,7 +156,13 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 				},
 			}
 		}
-		if line.Document.Type != "" {
+		// MDT-91: the referenced invoice's document type code. Prefer the
+		// untdid-document-type extension (the canonical GOBL representation
+		// for a document reference, as gobl.ubl emits) and fall back to the
+		// legacy Type key.
+		if dt := line.Document.Ext.Get(untdid.ExtKeyDocumentType); dt != "" {
+			ref.TypeCode = dt.String()
+		} else if line.Document.Type != "" {
 			ref.TypeCode = string(line.Document.Type)
 		}
 	}

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -356,6 +356,11 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 				due := amount
 				line.Due = &due
 			case flow6.ConditionAmountReceived, flow6.ConditionAmountPaid:
+				// The cashed amount (MDT-215). This assumes a single
+				// cashed-amount characteristic; a 212 whose amount is split
+				// across several VAT rates repeats this characteristic per
+				// rate, in which case only the last rate's amount is kept here
+				// (the per-rate VAT breakdown below is still captured in full).
 				line.Amount = amount
 				pmt.Ext = pmt.Ext.Set(flow6.ExtKeyCondition, cbc.Code(dc.TypeCode))
 			}

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -364,11 +364,10 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 				line.Amount = amount
 				pmt.Ext = pmt.Ext.Set(flow6.ExtKeyCondition, cbc.Code(dc.TypeCode))
 			}
-			// MDT-224: a percentage on the characteristic means the cashed
-			// amount is split by VAT rate (BR-FR-CDV-14, 212 Encaissée). The
-			// amount is the gross (TTC) per rate; recover the base and VAT so
-			// the parsed payment carries the tax breakdown the Flow 6 rules
-			// require and the CDV round-trips.
+			// A percentage on the characteristic means the cashed amount is
+			// split by VAT rate (212 Encaissée). The amount is the gross (TTC)
+			// per rate; recover the base and VAT so the parsed payment carries
+			// the tax breakdown the Flow 6 rules require and the CDV round-trips.
 			if dc.ValuePercent != "" {
 				pct, err := num.PercentageFromString(dc.ValuePercent + "%")
 				if err != nil {

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/tax"
 )
 
 // NewCDARFromPayment converts a *bill.Payment into a CDAR XML document
@@ -166,13 +167,8 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 			ref.TypeCode = string(line.Document.Type)
 		}
 	}
-	if pmt.Supplier != nil {
-		if siren := partyIdentityCode(pmt.Supplier, schemeIDSIREN); siren != "" {
-			ref.IssuerTradeParty = &CDARTradeParty{
-				GlobalIDs: []*CDARGlobalID{{SchemeID: schemeIDSIREN, Value: siren}},
-			}
-		}
-	}
+	// MDT-129: the referenced invoice's issuer (seller, or buyer if self-billed).
+	ref.IssuerTradeParty = cdarReferencedIssuer(line.Document, pmt.Supplier, pmt.Customer)
 
 	// Amounts ride as document characteristics on a single status
 	// entry: the payment's condition extension types the line amount
@@ -340,6 +336,8 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 	if dr := goblDocRefFromCDAR(ref); dr != nil {
 		line.Document = dr
 	}
+	var vatRates []*tax.RateTotal
+	var vatSum *num.Amount
 	for _, ds := range ref.SpecifiedDocumentStatuses {
 		if ds == nil {
 			continue
@@ -363,6 +361,40 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 				line.Amount = amount
 				pmt.Ext = pmt.Ext.Set(flow6.ExtKeyCondition, cbc.Code(dc.TypeCode))
 			}
+			// MDT-224: a percentage on the characteristic means the cashed
+			// amount is split by VAT rate (BR-FR-CDV-14, 212 Encaissée). The
+			// amount is the gross (TTC) per rate; recover the base and VAT so
+			// the parsed payment carries the tax breakdown the Flow 6 rules
+			// require and the CDV round-trips.
+			if dc.ValuePercent != "" {
+				pct, err := num.PercentageFromString(dc.ValuePercent + "%")
+				if err != nil {
+					continue
+				}
+				vat := pct.From(amount)
+				vatRates = append(vatRates, &tax.RateTotal{
+					Base:    amount.Divide(pct.Factor()),
+					Percent: &pct,
+					Amount:  vat,
+				})
+				if vatSum == nil {
+					sum := vat
+					vatSum = &sum
+				} else {
+					sum := vatSum.Add(vat)
+					vatSum = &sum
+				}
+			}
+		}
+	}
+	if len(vatRates) > 0 && vatSum != nil {
+		line.Tax = &tax.Total{
+			Categories: []*tax.CategoryTotal{{
+				Code:   tax.CategoryVAT,
+				Rates:  vatRates,
+				Amount: *vatSum,
+			}},
+			Sum: *vatSum,
 		}
 	}
 	return line

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -201,8 +201,10 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 // newCDARVATSplitCharacteristics breaks a payment line's cashed amount
 // down by VAT rate into one MDT-215 (ValueAmount, gross per rate) /
 // MDT-224 (ValuePercent) characteristic per distinct rate, as PPF
-// requires for an encaissement. Returns nil when the line carries no
-// tax breakdown so the caller can keep the amount-only form.
+// requires for an encaissement. The amount is derived entirely from the
+// rate (Base+Amount), not from line.Amount, which is just their sum. An
+// exempt or zero rate emits a 0.00 percentage. Returns nil when the line
+// carries no tax breakdown so the caller can keep the amount-only form.
 func newCDARVATSplitCharacteristics(typeCode cbc.Code, line *bill.PaymentLine, cur currency.Code) []*CDARDocumentCharacteristic {
 	if line == nil || line.Tax == nil {
 		return nil
@@ -213,14 +215,23 @@ func newCDARVATSplitCharacteristics(typeCode cbc.Code, line *bill.PaymentLine, c
 			continue
 		}
 		for _, rt := range cat.Rates {
-			if rt == nil || rt.Percent == nil {
+			if rt == nil {
 				continue
+			}
+			// The MEN characteristic has a single percentage field and no
+			// exemption concept, and P1.18 requires MDT-224 whenever the
+			// amount (MDT-215) is present. An exempt rate (Percent nil) and a
+			// zero rate therefore both surface as 0.00 — GOBL keeps them
+			// apart, the CDV cannot.
+			pct := "0.00"
+			if rt.Percent != nil {
+				pct = rt.Percent.Amount().Rescale(2).String()
 			}
 			gross := rt.Base.Add(rt.Amount)
 			chars = append(chars, &CDARDocumentCharacteristic{
 				TypeCode:     typeCode.String(),
 				ValueAmount:  &CDARValueAmount{Value: gross.String(), CurrencyID: cur.String()},
-				ValuePercent: rt.Percent.Amount().Rescale(2).String(),
+				ValuePercent: pct,
 			})
 		}
 	}
@@ -336,6 +347,7 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 	}
 	var vatRates []*tax.RateTotal
 	var vatSum *num.Amount
+	var cashed *num.Amount
 	for _, ds := range ref.SpecifiedDocumentStatuses {
 		if ds == nil {
 			continue
@@ -356,12 +368,17 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 				due := amount
 				line.Due = &due
 			case flow6.ConditionAmountReceived, flow6.ConditionAmountPaid:
-				// The cashed amount (MDT-215). This assumes a single
-				// cashed-amount characteristic; a 212 whose amount is split
-				// across several VAT rates repeats this characteristic per
-				// rate, in which case only the last rate's amount is kept here
-				// (the per-rate VAT breakdown below is still captured in full).
-				line.Amount = amount
+				// The cashed amount (MDT-215). When it is split across several
+				// VAT rates the characteristic repeats once per rate, each
+				// carrying that rate's gross; sum them so Amount holds the
+				// full cashed total rather than the last rate alone.
+				if cashed == nil {
+					c := amount
+					cashed = &c
+				} else {
+					c := cashed.Add(amount)
+					cashed = &c
+				}
 				pmt.Ext = pmt.Ext.Set(flow6.ExtKeyCondition, cbc.Code(dc.TypeCode))
 			}
 			// A percentage on the characteristic means the cashed amount is
@@ -388,6 +405,9 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 				}
 			}
 		}
+	}
+	if cashed != nil {
+		line.Amount = *cashed
 	}
 	if len(vatRates) > 0 && vatSum != nil {
 		line.Tax = &tax.Total{

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -157,14 +157,12 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 				},
 			}
 		}
-		// MDT-91: the referenced invoice's document type code. Prefer the
-		// untdid-document-type extension (the canonical GOBL representation
-		// for a document reference, as gobl.ubl emits) and fall back to the
-		// legacy Type key.
+		// MDT-91: the referenced invoice's document type code, from the
+		// canonical untdid-document-type extension. The flow6 addon migrates a
+		// legacy Type key into this extension on normalize and requires it, so
+		// a calculated document always carries it — no Type fallback needed.
 		if dt := line.Document.Ext.Get(untdid.ExtKeyDocumentType); dt != "" {
 			ref.TypeCode = dt.String()
-		} else if line.Document.Type != "" {
-			ref.TypeCode = string(line.Document.Type)
 		}
 	}
 	// MDT-129: the referenced invoice's issuer (its supplier).

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -167,8 +167,8 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 			ref.TypeCode = string(line.Document.Type)
 		}
 	}
-	// MDT-129: the referenced invoice's issuer (seller, or buyer if self-billed).
-	ref.IssuerTradeParty = cdarReferencedIssuer(line.Document, pmt.Supplier, pmt.Customer)
+	// MDT-129: the referenced invoice's issuer (its supplier).
+	ref.IssuerTradeParty = cdarReferencedIssuer(line.Document, pmt.Supplier)
 
 	// Amounts ride as document characteristics on a single status
 	// entry: the payment's condition extension types the line amount

--- a/cdar_payment_split_test.go
+++ b/cdar_payment_split_test.go
@@ -1,0 +1,160 @@
+package cii_test
+
+import (
+	"testing"
+
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vatRate is a small helper: a nil percent means the rate is exempt.
+func vatRate(base, amount num.Amount, percent *num.Percentage) *tax.RateTotal {
+	return &tax.RateTotal{Base: base, Percent: percent, Amount: amount}
+}
+
+func amt(v int64) num.Amount { return num.MakeAmount(v, 2) }
+
+func pct(v int64) *num.Percentage {
+	p := num.MakePercentage(v, 2)
+	return &p
+}
+
+// Expected CDV values, named to keep the case table readable (and to
+// satisfy goconst, which flags repeated string literals).
+const (
+	rate20   = "20.00"  // standard rate
+	rateZero = "0.00"   // zero rate / exempt collapse
+	grossStd = "600.00" // 500.00 base + 100.00 VAT @ 20%
+	grossRed = "220.00" // 200.00 base + 20.00 VAT @ 10%
+	grossZro = "300.00" // 300.00 base, no VAT
+)
+
+// TestCDARPaymentVATSplitRoundTrip exercises the cashed-amount ⇄ VAT-rate
+// mapping for an encaissement (212). The CDV expresses the cashed amount as
+// one MEN characteristic per rate — each carrying that rate's gross (TTC) and
+// its percentage — with no separate global total. On the GOBL side the
+// payment line holds a single Amount (the total cashed) plus N rates; Amount
+// is therefore the sum of the per-rate grosses. Exempt and zero rates both
+// collapse to 0.00 in the CDV.
+func TestCDARPaymentVATSplitRoundTrip(t *testing.T) {
+	type wantChar struct {
+		amount  string
+		percent string
+	}
+	cases := []struct {
+		name       string
+		rates      []*tax.RateTotal
+		wantChars  []wantChar
+		wantAmount string // expected parsed line.Amount = Σ grosses
+	}{
+		{
+			name:       "single rate",
+			rates:      []*tax.RateTotal{vatRate(amt(50000), amt(10000), pct(20))}, // 500 + 100
+			wantChars:  []wantChar{{grossStd, rate20}},
+			wantAmount: grossStd,
+		},
+		{
+			name: "multiple rates",
+			rates: []*tax.RateTotal{
+				vatRate(amt(50000), amt(10000), pct(20)), // gross 600.00
+				vatRate(amt(20000), amt(2000), pct(10)),  // gross 220.00
+			},
+			wantChars:  []wantChar{{grossStd, rate20}, {grossRed, "10.00"}},
+			wantAmount: "820.00",
+		},
+		{
+			name:       "zero rate",
+			rates:      []*tax.RateTotal{vatRate(amt(30000), amt(0), pct(0))}, // gross 300.00
+			wantChars:  []wantChar{{grossZro, rateZero}},
+			wantAmount: grossZro,
+		},
+		{
+			name:       "exempt (nil percent)",
+			rates:      []*tax.RateTotal{vatRate(amt(30000), amt(0), nil)}, // gross 300.00
+			wantChars:  []wantChar{{grossZro, rateZero}},
+			wantAmount: grossZro,
+		},
+		{
+			name: "mixed taxed and exempt",
+			rates: []*tax.RateTotal{
+				vatRate(amt(50000), amt(10000), pct(20)), // gross 600.00
+				vatRate(amt(30000), amt(0), nil),         // exempt, gross 300.00
+			},
+			wantChars:  []wantChar{{grossStd, rate20}, {grossZro, rateZero}},
+			wantAmount: "900.00",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pmt := buildSyntheticPayment(t, num.Amount{})
+			pmt.Lines[0].Tax = &tax.Total{
+				Categories: []*tax.CategoryTotal{{Code: tax.CategoryVAT, Rates: tc.rates}},
+			}
+
+			// --- generate: one MEN characteristic per rate ---
+			cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+			require.NoError(t, err)
+			ref := cdar.AcknowledgementDocuments[0].ReferenceReferencedDocument[0]
+			require.Len(t, ref.SpecifiedDocumentStatuses, 1)
+			chars := ref.SpecifiedDocumentStatuses[0].SpecifiedDocumentCharacteristics
+			require.Len(t, chars, len(tc.wantChars), "one characteristic per rate")
+			for i, wc := range tc.wantChars {
+				assert.Equal(t, "MEN", chars[i].TypeCode)
+				require.NotNil(t, chars[i].ValueAmount)
+				assert.Equal(t, wc.amount, chars[i].ValueAmount.Value, "MDT-215 gross per rate")
+				assert.Equal(t, wc.percent, chars[i].ValuePercent, "MDT-224 rate (exempt→0.00)")
+			}
+
+			// --- parse: Amount is the sum of the grosses, rates recovered ---
+			data, err := cdar.Bytes()
+			require.NoError(t, err)
+			out, err := cii.ParseCDARPayment(data)
+			require.NoError(t, err)
+			require.Len(t, out.Lines, 1)
+			assert.Equal(t, tc.wantAmount, out.Lines[0].Amount.String(),
+				"line.Amount must be the total cashed (Σ per-rate grosses)")
+
+			require.NotNil(t, out.Lines[0].Tax)
+			require.Len(t, out.Lines[0].Tax.Categories, 1)
+			gotRates := out.Lines[0].Tax.Categories[0].Rates
+			require.Len(t, gotRates, len(tc.wantChars), "one rate recovered per characteristic")
+			for i, wc := range tc.wantChars {
+				require.NotNil(t, gotRates[i].Percent, "parse reconstructs a concrete rate (0.00 for exempt)")
+				assert.Equal(t, wc.percent, gotRates[i].Percent.Amount().Rescale(2).String())
+			}
+		})
+	}
+}
+
+// TestCDARPaymentAmountDerivedFromRates proves the CDV amount comes from the
+// tax breakdown, not from line.Amount: a deliberately wrong line.Amount does
+// not leak into the characteristics.
+func TestCDARPaymentAmountDerivedFromRates(t *testing.T) {
+	pmt := buildSyntheticPayment(t, num.Amount{})
+	pmt.Lines[0].Amount = amt(999999) // bogus; must be ignored on generate
+	pmt.Lines[0].Tax = &tax.Total{
+		Categories: []*tax.CategoryTotal{{Code: tax.CategoryVAT, Rates: []*tax.RateTotal{
+			vatRate(amt(50000), amt(10000), pct(20)), // gross 600.00
+			vatRate(amt(20000), amt(2000), pct(10)),  // gross 220.00
+		}}},
+	}
+
+	cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+	require.NoError(t, err)
+	chars := cdar.AcknowledgementDocuments[0].ReferenceReferencedDocument[0].
+		SpecifiedDocumentStatuses[0].SpecifiedDocumentCharacteristics
+	require.Len(t, chars, 2)
+	assert.Equal(t, grossStd, chars[0].ValueAmount.Value)
+	assert.Equal(t, grossRed, chars[1].ValueAmount.Value)
+
+	data, err := cdar.Bytes()
+	require.NoError(t, err)
+	out, err := cii.ParseCDARPayment(data)
+	require.NoError(t, err)
+	assert.Equal(t, "820.00", out.Lines[0].Amount.String(),
+		"parsed Amount is the Σ of grosses, not the bogus input")
+}

--- a/cdar_status.go
+++ b/cdar_status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
@@ -296,7 +297,11 @@ func newCDARAcknowledgement(st *bill.Status, line *bill.StatusLine, ackType stri
 				},
 			}
 		}
-		if line.Doc.Type != "" {
+		// MDT-91: prefer the untdid-document-type extension (canonical for a
+		// document reference), fall back to the legacy Type key.
+		if dt := line.Doc.Ext.Get(untdid.ExtKeyDocumentType); dt != "" {
+			ref.TypeCode = dt.String()
+		} else if line.Doc.Type != "" {
 			ref.TypeCode = string(line.Doc.Type)
 		}
 	}

--- a/cdar_status.go
+++ b/cdar_status.go
@@ -305,13 +305,8 @@ func newCDARAcknowledgement(st *bill.Status, line *bill.StatusLine, ackType stri
 			ref.TypeCode = string(line.Doc.Type)
 		}
 	}
-	if st.Supplier != nil {
-		if siren := partyIdentityCode(st.Supplier, schemeIDSIREN); siren != "" {
-			ref.IssuerTradeParty = &CDARTradeParty{
-				GlobalIDs: []*CDARGlobalID{{SchemeID: schemeIDSIREN, Value: siren}},
-			}
-		}
-	}
+	// MDT-129: the referenced invoice's issuer (seller, or buyer if self-billed).
+	ref.IssuerTradeParty = cdarReferencedIssuer(line.Doc, st.Supplier, st.Customer)
 
 	// Build the SpecifiedDocumentStatus list. Pair each Reason with each
 	// Action when both are present, or emit one per Reason / Action alone.
@@ -517,7 +512,13 @@ func partyIdentityCode(p *org.Party, scheme string) string {
 	if p == nil {
 		return ""
 	}
-	for _, id := range p.Identities {
+	return identitiesSIREN(p.Identities, scheme)
+}
+
+// identitiesSIREN returns the code of the first identity carrying the given
+// ISO/IEC 6523 scheme extension, or "".
+func identitiesSIREN(ids []*org.Identity, scheme string) string {
+	for _, id := range ids {
 		if id == nil || id.Ext.IsZero() {
 			continue
 		}
@@ -526,6 +527,35 @@ func partyIdentityCode(p *org.Party, scheme string) string {
 		}
 	}
 	return ""
+}
+
+// cdarReferencedIssuer builds the MDT-129 referenced-invoice issuer party for a
+// CDV — whoever legally issued the invoice the status/payment is about.
+//
+// The doc ref's own Identities win when present: that is the faithful issuer a
+// parsed CDAR round-trips (or one an informed caller set), and it names the
+// real issuer regardless of self-billing or richer party info. When absent, the
+// issuer is derived by role — the seller (supplier) normally, or the buyer
+// (customer) when the referenced invoice is self-billed and the buyer issues it
+// in the seller's name.
+func cdarReferencedIssuer(docRef *org.DocumentRef, supplier, customer *org.Party) *CDARTradeParty {
+	var siren string
+	if docRef != nil {
+		siren = identitiesSIREN(docRef.Identities, schemeIDSIREN)
+	}
+	if siren == "" {
+		issuer := supplier
+		if docRef != nil && flow6.IsSelfBilledDocType(docRef.Ext.Get(untdid.ExtKeyDocumentType)) {
+			issuer = customer
+		}
+		siren = partyIdentityCode(issuer, schemeIDSIREN)
+	}
+	if siren == "" {
+		return nil
+	}
+	return &CDARTradeParty{
+		GlobalIDs: []*CDARGlobalID{{SchemeID: schemeIDSIREN, Value: siren}},
+	}
 }
 
 // markPPFReferences applies the PPF (einvoicingF2) profile corrections

--- a/cdar_status.go
+++ b/cdar_status.go
@@ -297,12 +297,11 @@ func newCDARAcknowledgement(st *bill.Status, line *bill.StatusLine, ackType stri
 				},
 			}
 		}
-		// MDT-91: prefer the untdid-document-type extension (canonical for a
-		// document reference), fall back to the legacy Type key.
+		// MDT-91: from the canonical untdid-document-type extension. The flow6
+		// addon migrates a legacy Type key into it on normalize and requires
+		// it, so a calculated document always carries it — no Type fallback.
 		if dt := line.Doc.Ext.Get(untdid.ExtKeyDocumentType); dt != "" {
 			ref.TypeCode = dt.String()
-		} else if line.Doc.Type != "" {
-			ref.TypeCode = string(line.Doc.Type)
 		}
 	}
 	// MDT-129: the referenced invoice's issuer (its supplier).

--- a/cdar_status.go
+++ b/cdar_status.go
@@ -305,8 +305,8 @@ func newCDARAcknowledgement(st *bill.Status, line *bill.StatusLine, ackType stri
 			ref.TypeCode = string(line.Doc.Type)
 		}
 	}
-	// MDT-129: the referenced invoice's issuer (seller, or buyer if self-billed).
-	ref.IssuerTradeParty = cdarReferencedIssuer(line.Doc, st.Supplier, st.Customer)
+	// MDT-129: the referenced invoice's issuer (its supplier).
+	ref.IssuerTradeParty = cdarReferencedIssuer(line.Doc, st.Supplier)
 
 	// Build the SpecifiedDocumentStatus list. Pair each Reason with each
 	// Action when both are present, or emit one per Reason / Action alone.
@@ -530,25 +530,22 @@ func identitiesSIREN(ids []*org.Identity, scheme string) string {
 }
 
 // cdarReferencedIssuer builds the MDT-129 referenced-invoice issuer party for a
-// CDV — whoever legally issued the invoice the status/payment is about.
+// CDV — the party that issued the invoice the status/payment is about.
 //
 // The doc ref's own Identities win when present: that is the faithful issuer a
-// parsed CDAR round-trips (or one an informed caller set), and it names the
-// real issuer regardless of self-billing or richer party info. When absent, the
-// issuer is derived by role — the seller (supplier) normally, or the buyer
-// (customer) when the referenced invoice is self-billed and the buyer issues it
-// in the seller's name.
-func cdarReferencedIssuer(docRef *org.DocumentRef, supplier, customer *org.Party) *CDARTradeParty {
+// parsed CDAR round-trips (or one an informed caller set), and it carries
+// richer info than a single derived SIREN. When absent, the issuer is the
+// invoice supplier (seller). PPF names the supplier as the referenced-invoice
+// issuer even for a self-billed invoice (UNTDID 389) — confirmed on QUAL
+// 2026-07-15, where PPF's own 250 ack for a self-billed extract reported the
+// supplier SIREN as MDT-129 — so there is no buyer swap for self-billing.
+func cdarReferencedIssuer(docRef *org.DocumentRef, supplier *org.Party) *CDARTradeParty {
 	var siren string
 	if docRef != nil {
 		siren = identitiesSIREN(docRef.Identities, schemeIDSIREN)
 	}
 	if siren == "" {
-		issuer := supplier
-		if docRef != nil && flow6.IsSelfBilledDocType(docRef.Ext.Get(untdid.ExtKeyDocumentType)) {
-			issuer = customer
-		}
-		siren = partyIdentityCode(issuer, schemeIDSIREN)
+		siren = partyIdentityCode(supplier, schemeIDSIREN)
 	}
 	if siren == "" {
 		return nil

--- a/cdar_status_parse.go
+++ b/cdar_status_parse.go
@@ -10,6 +10,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
@@ -287,7 +288,10 @@ func goblDocRefFromCDAR(ref *CDARReferencedDocument) *org.DocumentRef {
 	}
 	dr := &org.DocumentRef{Code: cbc.Code(ref.IssuerAssignedID)}
 	if ref.TypeCode != "" {
-		dr.Type = cbc.Key(ref.TypeCode)
+		// MDT-91 → the canonical untdid-document-type extension (not the Type
+		// key), so the referenced type is represented the same way inbound and
+		// outbound and downstream can always rely on the extension.
+		dr.Ext = dr.Ext.Set(untdid.ExtKeyDocumentType, cbc.Code(ref.TypeCode))
 	}
 	if ref.FormattedIssueDateTime != nil && ref.FormattedIssueDateTime.DateTimeString != nil {
 		d, _, err := parseCDARDateTime(ref.FormattedIssueDateTime.DateTimeString.Value)

--- a/cdar_status_test.go
+++ b/cdar_status_test.go
@@ -399,8 +399,8 @@ func buildSyntheticPayment(t *testing.T, due num.Amount) *bill.Payment {
 		},
 		Amount: num.MakeAmount(50000, 2),
 	}
-	// A 212 Encaissée must split the cashed amount by VAT rate (MDT-224,
-	// BR-FR-CDV-14): 500.00 TTC = 416.67 base + 83.33 VAT @ 20%.
+	// A 212 Encaissée with an amount must carry the VAT rate:
+	// 500.00 TTC = 416.67 base + 83.33 VAT @ 20%.
 	pct := num.MakePercentage(20, 2)
 	line.Tax = &tax.Total{
 		Categories: []*tax.CategoryTotal{{

--- a/cdar_status_test.go
+++ b/cdar_status_test.go
@@ -399,6 +399,17 @@ func buildSyntheticPayment(t *testing.T, due num.Amount) *bill.Payment {
 		},
 		Amount: num.MakeAmount(50000, 2),
 	}
+	// A 212 Encaissée must split the cashed amount by VAT rate (MDT-224,
+	// BR-FR-CDV-14): 500.00 TTC = 416.67 base + 83.33 VAT @ 20%.
+	pct := num.MakePercentage(20, 2)
+	line.Tax = &tax.Total{
+		Categories: []*tax.CategoryTotal{{
+			Code:   tax.CategoryVAT,
+			Rates:  []*tax.RateTotal{{Base: num.MakeAmount(41667, 2), Percent: &pct, Amount: num.MakeAmount(8333, 2)}},
+			Amount: num.MakeAmount(8333, 2),
+		}},
+		Sum: num.MakeAmount(8333, 2),
+	}
 	if !due.IsZero() {
 		line.Due = &due
 	}

--- a/cii.go
+++ b/cii.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl.fr.ctc/addon/flow2"
@@ -278,29 +279,54 @@ func Parse(data []byte, opts ...ParseOption) (*gobl.Envelope, error) {
 		return nil, err
 	}
 
-	env := gobl.NewEnvelope()
+	var res any
 	switch ns {
 	case NamespaceRSM:
-		res, err := parseInvoice(data)
-		if err != nil {
-			return nil, err
-		}
-		if err := env.Insert(res); err != nil {
-			return nil, err
-		}
-		return env, nil
+		res, err = parseInvoice(data)
 	case NamespaceCDARRSM:
-		res, err := parseCDAR(data, r)
-		if err != nil {
-			return nil, err
-		}
-		if err := env.Insert(res); err != nil {
-			return nil, err
-		}
-		return env, nil
+		res, err = parseCDAR(data, r)
 	default:
 		return nil, ErrUnknownDocumentType
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	env := gobl.NewEnvelope()
+
+	// A parsed document is one we received: its transport addresses are the
+	// ones the Peppol layer routed it with (who sent it → who received it),
+	// supplied via WithRouting. Set Head.From / Head.To from those args BEFORE
+	// calculation so GOBL respects them — normalizeRouting only fills empty
+	// routing fields, so it won't overwrite these with the document-derived,
+	// OUTGOING-direction guess (supplier → customer) that is wrong for a
+	// received document.
+	env.Head.From = participantURI(r.from)
+	env.Head.To = participantURI(r.to)
+
+	if err := env.Insert(res); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// peppolParticipantAuthority is the ISO 6523 actor-id URI authority Peppol
+// participant identifiers are qualified with.
+const peppolParticipantAuthority = "iso6523-actorid-upis"
+
+// participantURI canonicalizes a Peppol participant id — accepted in either
+// "scheme:code" or "iso6523-actorid-upis::scheme:code" form — to the full
+// absolute-URI form GOBL requires on Head.From / Head.To. Empty in, empty out.
+func participantURI(uri cbc.URI) cbc.URI {
+	s := string(uri)
+	if s == "" {
+		return ""
+	}
+	if strings.Contains(s, "::") {
+		return uri // already authority-qualified
+	}
+	return cbc.URI(peppolParticipantAuthority + "::" + s)
 }
 
 // routing carries the envelope's transport addresses (the SBD From / To the

--- a/examples_test.go
+++ b/examples_test.go
@@ -547,3 +547,27 @@ func removeLastEntry(dir string) string {
 	i := strings.LastIndex(dir, lastEntry)
 	return dir[:i]
 }
+
+// TestParseRoutingFromArgs verifies that a received CDAR takes its transport
+// Head.From/To from the routing args (who routed it to us), overriding GOBL's
+// document-derived, outgoing (supplier->customer) assumption. The 212's
+// outgoing From would be the supplier (100000009); the args here are the
+// REVERSE, so seeing 200000008 as From proves the args win.
+func TestParseRoutingFromArgs(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(getParsePath(), "UC1_F202500003_07-CDV-212_Encaissee.xml"))
+	require.NoError(t, err)
+
+	t.Run("short-form args are canonicalized onto Head.From/To", func(t *testing.T) {
+		env, err := cii.Parse(data, cii.WithRouting("0225:200000008_STATUTS", "0225:100000009_STATUTS"))
+		require.NoError(t, err)
+		assert.Equal(t, "iso6523-actorid-upis::0225:200000008_STATUTS", string(env.Head.From))
+		assert.Equal(t, "iso6523-actorid-upis::0225:100000009_STATUTS", string(env.Head.To))
+	})
+
+	t.Run("already-qualified args are kept verbatim", func(t *testing.T) {
+		env, err := cii.Parse(data, cii.WithRouting("iso6523-actorid-upis::0225:200000008_STATUTS", ""))
+		require.NoError(t, err)
+		assert.Equal(t, "iso6523-actorid-upis::0225:200000008_STATUTS", string(env.Head.From))
+	})
+
+}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/gobl.fr.ctc v0.0.4
+	github.com/invopop/gobl.fr.ctc v0.0.7
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/magefile/mage v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.500.0 h1:Ob3uO8wCywDkzJFpKI8zsUY/pL0sYsFobZlfRAZjd44=
 github.com/invopop/gobl v0.500.0/go.mod h1:EGDHHuPbF8JxRfct0q/s9t7ei2gjkOwjH3SytjB3aS0=
-github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
-github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
+github.com/invopop/gobl.fr.ctc v0.0.7 h1:O/ihT1EcFA7o8FuYG7EbL6LMVJ/rQrWV/C1nY5ryieo=
+github.com/invopop/gobl.fr.ctc v0.0.7/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/invopop/phive v0.6.0 h1:wtk5+ieD/muViF6SJXGGVA/vYPzed9NoaCl63TjmWU4=

--- a/test/data/convert/cdar-PPF/out/payment-212-encaissee.xml
+++ b/test/data/convert/cdar-PPF/out/payment-212-encaissee.xml
@@ -56,6 +56,7 @@
         <ram:SpecifiedDocumentCharacteristic>
           <ram:TypeCode>MEN</ram:TypeCode>
           <ram:ValueAmount currencyID="EUR">500.00</ram:ValueAmount>
+          <ram:ValuePercent>20.00</ram:ValuePercent>
         </ram:SpecifiedDocumentCharacteristic>
         <ram:SpecifiedDocumentCharacteristic>
           <ram:TypeCode>RAP</ram:TypeCode>

--- a/test/data/convert/cdar-PPF/payment-212-encaissee.json
+++ b/test/data/convert/cdar-PPF/payment-212-encaissee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8402e7d6260a81f600db6b5559757b99826963047387f13a4445a979507f7103"
+			"val": "007520e52576915d6540b0f3926044d557d5da9657730176bf888d22fa859fe2"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_PEP",
 		"to": "iso6523-actorid-upis::0225:200000008_PEP"
@@ -81,10 +81,29 @@
 				"document": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"amount": "500.00",
-				"due": "250.00"
+				"due": "250.00",
+				"tax": {
+					"categories": [
+						{
+							"code": "VAT",
+							"rates": [
+								{
+									"base": "416.67",
+									"percent": "20%",
+									"amount": "83.33"
+								}
+							],
+							"amount": "83.33"
+						}
+					],
+					"sum": "83.33"
+				}
 			}
 		],
 		"methods": [

--- a/test/data/convert/cdar-PPF/status-200-deposee.json
+++ b/test/data/convert/cdar-PPF/status-200-deposee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fd77f56957a5db671395c9773aeecac8cc4e05cb2321dc8a9f75be7f7e001c81"
+			"val": "0824567a500bd55c145c1d829ec1d932d0b923214c20186415e6c5b215a477e7"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_PEP",
 		"to": "iso6523-actorid-upis::0225:200000008_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "200"

--- a/test/data/convert/cdar/out/payment-212-encaissee.xml
+++ b/test/data/convert/cdar/out/payment-212-encaissee.xml
@@ -58,6 +58,7 @@
         <ram:SpecifiedDocumentCharacteristic>
           <ram:TypeCode>MEN</ram:TypeCode>
           <ram:ValueAmount currencyID="EUR">500.00</ram:ValueAmount>
+          <ram:ValuePercent>20.00</ram:ValuePercent>
         </ram:SpecifiedDocumentCharacteristic>
         <ram:SpecifiedDocumentCharacteristic>
           <ram:TypeCode>RAP</ram:TypeCode>

--- a/test/data/convert/cdar/payment-212-encaissee.json
+++ b/test/data/convert/cdar/payment-212-encaissee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8402e7d6260a81f600db6b5559757b99826963047387f13a4445a979507f7103"
+			"val": "007520e52576915d6540b0f3926044d557d5da9657730176bf888d22fa859fe2"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_PEP",
 		"to": "iso6523-actorid-upis::0225:200000008_PEP"
@@ -81,10 +81,29 @@
 				"document": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"amount": "500.00",
-				"due": "250.00"
+				"due": "250.00",
+				"tax": {
+					"categories": [
+						{
+							"code": "VAT",
+							"rates": [
+								{
+									"base": "416.67",
+									"percent": "20%",
+									"amount": "83.33"
+								}
+							],
+							"amount": "83.33"
+						}
+					],
+					"sum": "83.33"
+				}
 			}
 		],
 		"methods": [

--- a/test/data/convert/cdar/status-204-prise-en-charge.json
+++ b/test/data/convert/cdar/status-204-prise-en-charge.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fff032e382818e3ec7b706e346a636553ad763c4d436ad0dcc80625206cff163"
+			"val": "1b4f7e396dfa3cd848406ec2eb64aa71438da18fa963c07b3a03089e7584929b"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "204"

--- a/test/data/convert/cdar/status-205-approuvee.json
+++ b/test/data/convert/cdar/status-205-approuvee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7fda158c36ef7275cefdfe00f814c96ea68fc344ec31537f5bc99da343c51b8a"
+			"val": "c1afc52ffe280d59e919268ee940ccccfef2cd05990aa57e4da17714bf662051"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "205"

--- a/test/data/convert/cdar/status-206-approuvee-partiellement.json
+++ b/test/data/convert/cdar/status-206-approuvee-partiellement.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1e10040bc5ad5a0af8404bed1a3a93aaedae1b60bae29783cd882f512eeec501"
+			"val": "56c4daffe3456a4cf885b1b26148cdb4165d9db6549e8a321c3ea0b95506b6ca"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/convert/cdar/status-207-litige.json
+++ b/test/data/convert/cdar/status-207-litige.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4a93690332be011cb57e535b3a6a7604e32dec370bf6bdfb2bc08c2f35fac775"
+			"val": "13ec00523e7cc144a3b8bceac927e651c7badcdbcb0b380ca8c2e713d6396486"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/convert/cdar/status-208-suspendue.json
+++ b/test/data/convert/cdar/status-208-suspendue.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9b5c448a989dfbced6377ba608abc17e50b9f0a60ebec6c91cbab7cdf4c6b20d"
+			"val": "a3db1f374d686095a251182532472ea6b3a7cf0af379e3e3362ee2a4b3248970"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/convert/cdar/status-210-refusee.json
+++ b/test/data/convert/cdar/status-210-refusee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "691282960319ef77a398bde71f649831580ab0d75da43bac9d144bac24901aa5"
+			"val": "331e30bc8774ee4bf218e71a0abdfbdb6c988b870de2eb600b19f214cd2178f3"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/convert/cdar/status-213-rejetee-semantique.json
+++ b/test/data/convert/cdar/status-213-rejetee-semantique.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "13b9712081418dc3278a5da8658386f400fcd4a1a67c555ff6fcfd6225638709"
+			"val": "78c75e1376f5a9e296047310c7abf2b083fcc0d95da62374bceb5708430fcf80"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_PEP",
 		"to": "iso6523-actorid-upis::0225:100000009_PEP"
@@ -79,7 +79,10 @@
 				"doc": {
 					"type": "380",
 					"issue_date": "2025-07-01",
-					"code": "F202500003"
+					"code": "F202500003",
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/parse/out/UC1_F202500003_01-CDV-200_Deposee.json
+++ b/test/data/parse/out/UC1_F202500003_01-CDV-200_Deposee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4c0cc123a800414685e3b09136d2e75b6e66e836b35f0a16e83b7bf65c60e409"
+			"val": "79b7f8f819a5ed400f3cf013077385c564ab65d80b5f39848ad2fb94a3f0e8bd"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS"
 	},
@@ -50,7 +50,6 @@
 				"key": "issued",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -60,7 +59,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "200"

--- a/test/data/parse/out/UC1_F202500003_01-CDV-200_Deposee_POUR_PPF.json
+++ b/test/data/parse/out/UC1_F202500003_01-CDV-200_Deposee_POUR_PPF.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "5a05955395e99ab8c3972a9fba74d3f875873691dd1ba8b344246a9ae7be4cd1"
+			"val": "6f773600a5c40040f6c03cff211c9c2bda5f700f9124a15c61ff3003cae885bd"
 		}
 	},
 	"doc": {
@@ -36,7 +36,6 @@
 				"key": "issued",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -46,7 +45,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "200"

--- a/test/data/parse/out/UC1_F202500003_02-CDV-202_Recue.json
+++ b/test/data/parse/out/UC1_F202500003_02-CDV-202_Recue.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2beb952fe7a68b7288af9cc10019fde0bfe9c2be52aec131a23a3848a823bb63"
+			"val": "fdd8d86feb1f6dac39e397f6e59d13014dbcfa2b08814845e7b9027170bd5d96"
 		},
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
 	},
@@ -69,7 +69,6 @@
 				"key": "acknowledged",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -79,7 +78,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "202"

--- a/test/data/parse/out/UC1_F202500003_03-CDV-203_Mise_a_disposition.json
+++ b/test/data/parse/out/UC1_F202500003_03-CDV-203_Mise_a_disposition.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "c85a51482525fbf224b99f9c770e6d775d6a0764ce34f879869c7a7df78a3247"
+			"val": "c5cc514638edf388346e619d708e8f2ea359b082fb09cedba3c42e89592be749"
 		},
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
 	},
@@ -69,7 +69,6 @@
 				"key": "other",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -79,7 +78,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "203"

--- a/test/data/parse/out/UC1_F202500003_04-CDV-204_Prise_en_charge.json
+++ b/test/data/parse/out/UC1_F202500003_04-CDV-204_Prise_en_charge.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7f3352ba394ae627ef4f545bcbf7f5dd462775cad64130fee96558c765a00a5a"
+			"val": "5872ab839a2412a988d04a1778d26b7dfa309caa43f91c4b19e71f02c47318b0"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
@@ -77,7 +77,6 @@
 				"key": "processing",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -87,7 +86,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "204"

--- a/test/data/parse/out/UC1_F202500003_05-CDV-205_Approuvee.json
+++ b/test/data/parse/out/UC1_F202500003_05-CDV-205_Approuvee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "11f00ddefd2499b6b354bfd57a0a828faee47290b8f1298dabd0b668c884c67b"
+			"val": "9db3a090d3eb722c1acef44fdd380a5436265b7d93104ac8bf5e7c7f2fb6729d"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
@@ -77,7 +77,6 @@
 				"key": "accepted",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -87,7 +86,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"ext": {
 					"fr-ctc-flow6-status": "205"

--- a/test/data/parse/out/UC1_F202500003_06-CDV-211_Paiement_transmis.json
+++ b/test/data/parse/out/UC1_F202500003_06-CDV-211_Paiement_transmis.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9d2db7a50f07a4d004b87fc7e04c1014165964b2627f348a8110e9b9d918344b"
+			"val": "27b42f9ade172a1b90cb06e96371923594fd680d77f9a06bf408605a3eb9957d"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
@@ -80,7 +80,6 @@
 			{
 				"i": 1,
 				"document": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -90,7 +89,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"amount": "12000"
 			}

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "11c8a47ad5bfe99abd7bb842963474535a3d39686e4077522f7c0a0f74b7bee2"
+			"val": "a22ec36515fdb916226a654d2fcb1b441e7ef9b0ddc5a48caf3a9f9b30a498f4"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS",
 		"to": "iso6523-actorid-upis::0225:200000008"
@@ -94,7 +94,23 @@
 						"untdid-document-type": "380"
 					}
 				},
-				"amount": "12000"
+				"amount": "12000",
+				"tax": {
+					"categories": [
+						{
+							"code": "VAT",
+							"rates": [
+								{
+									"base": "10000",
+									"percent": "20.00%",
+									"amount": "2000"
+								}
+							],
+							"amount": "2000.00"
+						}
+					],
+					"sum": "2000.00"
+				}
 			}
 		],
 		"methods": [

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2f72240d9b376a5ffc154361c0aea58142b35a45ac32b00401b586e196084cd6"
+			"val": "11c8a47ad5bfe99abd7bb842963474535a3d39686e4077522f7c0a0f74b7bee2"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS",
 		"to": "iso6523-actorid-upis::0225:200000008"
@@ -80,7 +80,6 @@
 			{
 				"i": 1,
 				"document": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -90,7 +89,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"amount": "12000"
 			}

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "dcd98875c194444593bb25ea67bc7f561a03869779dc1923ef65cc59c88649e8"
+			"val": "bf35f531116485ef683f9d1d9ba48a889885d5b802ce5a85d7027616c832a7fb"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS"
 	},
@@ -67,7 +67,23 @@
 						"untdid-document-type": "380"
 					}
 				},
-				"amount": "12000"
+				"amount": "12000",
+				"tax": {
+					"categories": [
+						{
+							"code": "VAT",
+							"rates": [
+								{
+									"base": "10000",
+									"percent": "20.00%",
+									"amount": "2000"
+								}
+							],
+							"amount": "2000.00"
+						}
+					],
+					"sum": "2000.00"
+				}
 			}
 		],
 		"methods": [

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e20e94c7f21541eb2106d68b66cf34ae2343927190e1afc9aa3e1019680f5090"
+			"val": "dcd98875c194444593bb25ea67bc7f561a03869779dc1923ef65cc59c88649e8"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS"
 	},
@@ -53,7 +53,6 @@
 			{
 				"i": 1,
 				"document": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500003",
 					"identities": [
@@ -63,7 +62,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"amount": "12000"
 			}

--- a/test/data/parse/out/UC4_F202500006_04-CDV-207_En_litige.json
+++ b/test/data/parse/out/UC4_F202500006_04-CDV-207_En_litige.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1faeacbf97600b62e98166a271cda233ef9b820c25836941efc737248003002f"
+			"val": "330c94557a5491bd5ac608d25d7fbeb37f6839e18cc61a615ae472d5ed39839f"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
@@ -77,7 +77,6 @@
 				"key": "rejected",
 				"date": "2025-07-01",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-01",
 					"code": "F202500006",
 					"identities": [
@@ -87,7 +86,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{

--- a/test/data/parse/out/UC5_F202500007_04-CDV-207_En_litige.json
+++ b/test/data/parse/out/UC5_F202500007_04-CDV-207_En_litige.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "72c49ecae6792d664c685727e32f5147c79e44de406738de615025137a92889d"
+			"val": "62753c6180589e38c437747b799a471bef3f0b945a983be954ec9231c3a4b6ee"
 		},
 		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
 		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
@@ -77,7 +77,6 @@
 				"key": "rejected",
 				"date": "2025-07-02",
 				"doc": {
-					"type": "380",
 					"issue_date": "2025-07-02",
 					"code": "F202500007",
 					"identities": [
@@ -87,7 +86,10 @@
 								"iso-scheme-id": "0002"
 							}
 						}
-					]
+					],
+					"ext": {
+						"untdid-document-type": "380"
+					}
 				},
 				"reasons": [
 					{


### PR DESCRIPTION
The CDAR referenced-document TypeCode (MDT-91) reads the canonical `untdid-document-type` extension on the `DocumentRef` only. The flow6 addon migrates a legacy `Type` key into that extension on normalize and requires it (rules 17/25), so a calculated document always carries it — no `Type` fallback. Depends on gobl.fr.ctc, so merge that first.

Rationale: gobl.ubl already represents a document reference's type via that extension (`ordering.go`), and the invoice itself carries its type there. The CDAR path was the outlier, reading the raw `Type` key. This aligns it and lets flow6 enforce/normalise the type on the extension.
