### PR TITLE
feat: map ram:Description to/from party registration (BT-33)

### DIFF
--- a/party.go
+++ b/party.go
@@ -95,6 +95,11 @@ func newParty(party *org.Party, ctx Context) *Party {
 		}
 	}
 
+	// BT-33: additional legal information (ram:Description)
+	if party.Registration != nil && party.Registration.Other != "" {
+		p.Description = party.Registration.Other
+	}
+
 	if party.TaxID != nil && party.TaxID.Code != "" {
 		// Assumes VAT ID being used instead of possible tax number
 		p.SpecifiedTaxRegistration = []*SpecifiedTaxRegistration{

--- a/party_parse.go
+++ b/party_parse.go
@@ -20,6 +20,13 @@ func goblNewParty(party *Party) *org.Party {
 		}
 	}
 
+	// BT-33: additional legal information (ram:Description)
+	if party.Description != "" {
+		p.Registration = &org.Registration{
+			Other: party.Description,
+		}
+	}
+
 	// BT-30/BT-47: Legal registration identifier
 	if party.LegalOrganization != nil && party.LegalOrganization.ID != nil && party.LegalOrganization.ID.Value != "" {
 		identity := &org.Identity{

--- a/party_test.go
+++ b/party_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +47,35 @@ func TestNewSeller(t *testing.T) {
 		assert.Equal(t, "123456789", doc.Transaction.Agreement.Buyer.GlobalID.Value)
 		assert.Equal(t, "0088", doc.Transaction.Agreement.Buyer.GlobalID.SchemeID)
 	})
+}
+
+// TestPartyRegistration checks that BT-33 (additional legal information)
+// round-trips through ram:Description for both the seller (supplier) and
+// the buyer (customer).
+func TestPartyRegistration(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-complete.json")
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	inv.Supplier.Registration = &org.Registration{Other: "Share capital 100.000 EUR"}
+	inv.Customer.Registration = &org.Registration{Other: "GmbH"}
+	require.NoError(t, env.Calculate())
+
+	// GOBL -> CII
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+	assert.Equal(t, "Share capital 100.000 EUR", doc.Transaction.Agreement.Seller.Description)
+	assert.Equal(t, "GmbH", doc.Transaction.Agreement.Buyer.Description)
+
+	// CII -> GOBL
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+	back, err := cii.Parse(data)
+	require.NoError(t, err)
+	inv2, ok := back.Extract().(*bill.Invoice)
+	require.True(t, ok)
+	require.NotNil(t, inv2.Supplier.Registration)
+	assert.Equal(t, "Share capital 100.000 EUR", inv2.Supplier.Registration.Other)
+	require.NotNil(t, inv2.Customer.Registration)
+	assert.Equal(t, "GmbH", inv2.Customer.Registration.Other)
 }


### PR DESCRIPTION
## What

Maps the CII `ram:Description` element on the trade party — **BT-33 "Seller additional legal information"** in the EN 16931 semantic model — to and from GOBL's `org.Party.Registration`, for **both the seller (supplier) and buyer (customer)** parties.

## How

- **GOBL → CII** (`newParty` in `party.go`): when `party.Registration.Other` is set, emit it as `ram:Description`.
- **CII → GOBL** (`goblNewParty` in `party_parse.go`): when `ram:Description` is present, populate `party.registration.other`.

Both the seller and the buyer flow through these shared helpers, so the mapping covers both at once (`$.doc.supplier.registration` and `$.doc.customer.registration`).

The free-text value lands in `registration.other`, the catch-all field of `org.Registration` — the natural fit for BT-33's free-text legal information. This mirrors the equivalent change in gobl.ubl (`cbc:CompanyLegalForm`).

## Tests

Added `TestPartyRegistration`, a full round-trip (GOBL → CII XML → GOBL) asserting the value survives in both directions for supplier and customer. Full suite + `golangci-lint` (no new findings) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)