### PR TITLE
feat: map party electronic address via the endpoint object

### DIFF
--- a/party.go
+++ b/party.go
@@ -3,6 +3,7 @@ package cii
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/invopop/gobl/addons/fr/choruspro"
 	"github.com/invopop/gobl/catalogues/iso"
@@ -77,6 +78,25 @@ type Email struct {
 // SchemeIDEmail represents the Scheme ID for email addresses
 const SchemeIDEmail = "EM"
 
+// mailtoScheme is the URI scheme GOBL uses for email endpoints
+// (e.g. "mailto:billing@example.com").
+const mailtoScheme = "mailto"
+
+// peppolEndpointScheme is the URI scheme GOBL uses for Peppol participant
+// identifier endpoints (e.g. "iso6523-actorid-upis::9930:111111125").
+const peppolEndpointScheme = "iso6523-actorid-upis"
+
+// splitPeppolEndpoint splits the opaque part of an
+// "iso6523-actorid-upis::<scheme>:<code>" URI (which URL parsing exposes
+// as ":<scheme>:<code>") into its scheme and code components.
+func splitPeppolEndpoint(opaque string) (scheme, code string, ok bool) {
+	parts := strings.SplitN(strings.TrimPrefix(opaque, ":"), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
 // newParty creates the SellerTradeParty part of a EN 16931 compliant invoice
 func newParty(party *org.Party, ctx Context) *Party {
 	if party == nil {
@@ -150,7 +170,7 @@ func newParty(party *org.Party, ctx Context) *Party {
 		applyChorusPro(party, p)
 	}
 
-	p.URIUniversalCommunication = newURIUniversalCommunication(party.Inboxes)
+	p.URIUniversalCommunication = newURIUniversalCommunication(party)
 
 	if p.LegalOrganization != nil && p.LegalOrganization.ID != nil && p.LegalOrganization.ID.Value == "" {
 		p.LegalOrganization.ID = nil
@@ -272,24 +292,28 @@ func contactName(p *org.Name) string {
 	return fmt.Sprintf("%s %s", g, s)
 }
 
-func newURIUniversalCommunication(inboxes []*org.Inbox) *URIUniversalCommunication {
-	if len(inboxes) == 0 {
+// newURIUniversalCommunication maps a party's preferred electronic address
+// (its first endpoint) to a CII URIUniversalCommunication. It understands the
+// two URI forms emitted by GOBL normalization:
+//   - "mailto:<address>"                      -> schemeID "EM"
+//   - "iso6523-actorid-upis::<scheme>:<code>" -> schemeID "<scheme>"
+func newURIUniversalCommunication(party *org.Party) *URIUniversalCommunication {
+	ep := party.FirstEndpoint()
+	if ep == nil {
 		return nil
 	}
-	ib := inboxes[0]
-	if ib.Email != "" {
-		return &URIUniversalCommunication{
-			ID: &PartyID{
-				Value:    ib.Email,
-				SchemeID: SchemeIDEmail,
-			},
+	switch ep.URI.Scheme() {
+	case mailtoScheme:
+		if addr := ep.URI.Opaque(); addr != "" {
+			return &URIUniversalCommunication{
+				ID: &PartyID{Value: addr, SchemeID: SchemeIDEmail},
+			}
 		}
-	} else if ib.Code != "" {
-		return &URIUniversalCommunication{
-			ID: &PartyID{
-				Value:    ib.Code.String(),
-				SchemeID: ib.Scheme.String(),
-			},
+	case peppolEndpointScheme:
+		if scheme, code, ok := splitPeppolEndpoint(ep.URI.Opaque()); ok {
+			return &URIUniversalCommunication{
+				ID: &PartyID{Value: code, SchemeID: scheme},
+			}
 		}
 	}
 	return nil

--- a/party_parse.go
+++ b/party_parse.go
@@ -95,13 +95,29 @@ func goblPartyContact(party *Party, p *org.Party) {
 			}
 		}
 	}
-	if uc := party.URIUniversalCommunication; uc != nil {
-		if uc.ID.SchemeID == SchemeIDEmail {
-			p.Inboxes = []*org.Inbox{{Email: uc.ID.Value}}
-		} else {
-			p.Inboxes = []*org.Inbox{{Scheme: cbc.Code(uc.ID.SchemeID), Code: cbc.Code(uc.ID.Value)}}
+	if uc := party.URIUniversalCommunication; uc != nil && uc.ID != nil {
+		if ep := goblEndpoint(uc.ID.SchemeID, uc.ID.Value); ep != nil {
+			p.Endpoints = []*org.Endpoint{ep}
 		}
 	}
+}
+
+// goblEndpoint maps a CII URIUniversalCommunication (schemeID + value) to a
+// GOBL endpoint URI:
+//   - schemeID "EM" -> "mailto:<value>"
+//   - any other EAS -> "iso6523-actorid-upis::<schemeID>:<value>"
+func goblEndpoint(schemeID, value string) *org.Endpoint {
+	if value == "" || schemeID == "" {
+		return nil
+	}
+	var uri cbc.URI
+	switch schemeID {
+	case SchemeIDEmail: // email
+		uri = cbc.URI(mailtoScheme + ":" + value)
+	default:
+		uri = cbc.URI(peppolEndpointScheme + "::" + schemeID + ":" + value)
+	}
+	return &org.Endpoint{URI: uri}
 }
 
 func goblPartyTaxRegistrations(party *Party, p *org.Party) {

--- a/party_parse_test.go
+++ b/party_parse_test.go
@@ -65,7 +65,7 @@ func TestParseCtoGParty(t *testing.T) {
 		assert.Equal(t, "Salescompany ltd.", supplier.Name)
 		assert.Equal(t, cbc.Code("123456789"), supplier.TaxID.Code)
 		assert.Equal(t, l10n.TaxCountryCode("NO"), supplier.TaxID.Country)
-		assert.Equal(t, "inbox@example.com", supplier.Inboxes[0].Email)
+		assert.Equal(t, "mailto:inbox@example.com", supplier.Endpoints[0].URI.String())
 
 		require.Len(t, supplier.Addresses, 1)
 		assert.Equal(t, "Main street 34", supplier.Addresses[0].Street)
@@ -81,7 +81,7 @@ func TestParseCtoGParty(t *testing.T) {
 		require.Len(t, supplier.Telephones, 1)
 		assert.Equal(t, "46211230", supplier.Telephones[0].Number)
 
-		assert.Equal(t, "inbox@example.com", supplier.Inboxes[0].Email)
+		assert.Equal(t, "mailto:inbox@example.com", supplier.Endpoints[0].URI.String())
 
 		customer := inv.Customer
 		require.NotNil(t, customer)
@@ -107,7 +107,6 @@ func TestParseCtoGParty(t *testing.T) {
 		supplier := inv.Supplier
 		require.NotNil(t, supplier)
 
-		assert.Equal(t, "5566778899", supplier.Inboxes[0].Code.String())
-		assert.Equal(t, "0007", supplier.Inboxes[0].Scheme.String())
+		assert.Equal(t, "iso6523-actorid-upis::0007:5566778899", supplier.Endpoints[0].URI.String())
 	})
 }

--- a/test/data/convert/en16931/invoice-complete.json
+++ b/test/data/convert/en16931/invoice-complete.json
@@ -39,6 +39,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/en16931/invoice-de-de.json
+++ b/test/data/convert/en16931/invoice-de-de.json
@@ -38,6 +38,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0007:111111125"
+				}
+			],
 			"inboxes": [
 				{
 					"scheme": "0007",
@@ -76,6 +81,11 @@
 					"ext": {
 						"iso-scheme-id": "0088"
 					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
 				}
 			],
 			"inboxes": [
@@ -158,6 +168,11 @@
 						"name": {
 							"given": "Antonio Salesmacher"
 						}
+					}
+				],
+				"endpoints": [
+					{
+						"uri": "mailto:inbox@example.com"
 					}
 				],
 				"inboxes": [

--- a/test/data/convert/en16931/invoice-prices-include.json
+++ b/test/data/convert/en16931/invoice-prices-include.json
@@ -52,6 +52,11 @@
 					]
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "billing@example.com"

--- a/test/data/convert/facturx/invoice-complete.json
+++ b/test/data/convert/facturx/invoice-complete.json
@@ -39,6 +39,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/facturx/invoice-de-de.json
+++ b/test/data/convert/facturx/invoice-de-de.json
@@ -39,6 +39,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0007:111111125"
+				}
+			],
 			"inboxes": [
 				{
 					"scheme": "0007",
@@ -77,6 +82,11 @@
 					"ext": {
 						"iso-scheme-id": "0088"
 					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
 				}
 			],
 			"inboxes": [
@@ -155,6 +165,11 @@
 						"name": {
 							"given": "Antonio Salesmacher"
 						}
+					}
+				],
+				"endpoints": [
+					{
+						"uri": "mailto:inbox@example.com"
 					}
 				],
 				"inboxes": [

--- a/test/data/convert/xrechnung/invoice-credit.json
+++ b/test/data/convert/xrechnung/invoice-credit.json
@@ -50,6 +50,11 @@
 					]
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9920:ESB85905495"
+				}
+			],
 			"inboxes": [
 				{
 					"scheme": "9920",
@@ -83,6 +88,11 @@
 						"given": "IT",
 						"surname": "Team"
 					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9920:ESB85905495"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/xrechnung/invoice-de-de.json
+++ b/test/data/convert/xrechnung/invoice-de-de.json
@@ -45,6 +45,11 @@
 					]
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",
@@ -78,6 +83,11 @@
 						"given": "John",
 						"surname": "Doe"
 					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "mailto:customer@example.com"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/xrechnung/invoice-de-es-b2b.json
+++ b/test/data/convert/xrechnung/invoice-de-es-b2b.json
@@ -52,6 +52,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",
@@ -84,6 +89,11 @@
 				"country": "ES",
 				"code": "B98602642"
 			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9920:ESB85905495"
+				}
+			],
 			"inboxes": [
 				{
 					"scheme": "9920",


### PR DESCRIPTION
## What

Map the CII `ram:URIUniversalCommunication` (the party's electronic
address) to and from GOBL's `org.Party.Endpoints` — the `org.Endpoint`
URI — instead of the deprecated `org.Party.Inboxes`.

## Mapping

| GOBL endpoint URI | CII `URIUniversalCommunication/URIID` |
| --- | --- |
| `mailto:<address>` | `schemeID="EM"` value `<address>` |
| `iso6523-actorid-upis::<scheme>:<code>` | `schemeID="<scheme>"` value `<code>` |

This matches the URI convention GOBL's `eu/en16931` addon uses when it
normalizes Peppol inboxes into endpoints, extended to email (`mailto:`).

- **Serialize:** `newURIUniversalCommunication` reads `party.FirstEndpoint()`.
- **Parse:** `goblEndpoint` writes the inverse as an `org.Endpoint`.

## Test data

**Convert goldens are unchanged (byte-identical XML).** Each party
fixture gains an `endpoint` carrying exactly the value the old
inbox-based serializer emitted, so switching the source is a no-op on
the wire. This includes the `ordering.seller` party, which the DE flow
promotes to the `SellerTradeParty` (its email inbox now becomes a
`mailto:` endpoint).

## Out of scope

The **CDAR** status/acknowledgement flow (`cdar_*.go`) keeps its own
inbox handling — it has France-specific participant/routing logic tied
to the Chorus Pro BR-FR-CDV rules and already partially reads
`party.Endpoints` for routing. Migrating it fully is left as a
follow-up.

## Notes

Depends on GOBL's endpoint model; new builds normalized through the
`en16931` addon already carry endpoints. Paired with the equivalent
change in `gobl.ubl`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
