### PR TITLE
feat: map GOBL ordering issuer to InvoicerTradeParty

### DIFF
--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -26,6 +26,10 @@ func goblNewOrdering(in *Invoice) (*bill.Ordering, error) {
 		ord.Code = cbc.Code(tr.Agreement.BuyerReference)
 	}
 
+	if tr.Settlement.Invoicer != nil {
+		ord.Issuer = goblNewParty(tr.Settlement.Invoicer)
+	}
+
 	if tr.Agreement.Sales != nil {
 		ord.Sales = []*org.DocumentRef{
 			{
@@ -152,5 +156,6 @@ func goblOrderingHasData(ord *bill.Ordering) bool {
 		ord.Sales != nil ||
 		ord.Purchases != nil ||
 		ord.Projects != nil ||
-		ord.Contracts != nil
+		ord.Contracts != nil ||
+		ord.Issuer != nil
 }

--- a/ordering_test.go
+++ b/ordering_test.go
@@ -1,0 +1,55 @@
+package cii_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl"
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderingIssuer(t *testing.T) {
+	// issuerEnv loads a complete invoice and attaches an ordering issuer.
+	issuerEnv := func(t *testing.T) *gobl.Envelope {
+		t.Helper()
+		env := loadEnvelope(t, "en16931/invoice-de-de.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		if inv.Ordering == nil {
+			inv.Ordering = &bill.Ordering{}
+		}
+		inv.Ordering.Issuer = &org.Party{
+			Name: "Billing Service Provider SL",
+		}
+		require.NoError(t, env.Calculate())
+		return env
+	}
+
+	t.Run("maps ordering issuer to InvoicerTradeParty", func(t *testing.T) {
+		doc, err := cii.ConvertInvoice(issuerEnv(t))
+		require.NoError(t, err)
+
+		invoicer := doc.Transaction.Settlement.Invoicer
+		require.NotNil(t, invoicer, "Invoicer should be set from ordering.issuer")
+		assert.Equal(t, "Billing Service Provider SL", invoicer.Name)
+	})
+
+	t.Run("round-trips issuer back to GOBL ordering", func(t *testing.T) {
+		doc, err := cii.ConvertInvoice(issuerEnv(t))
+		require.NoError(t, err)
+		data, err := doc.Bytes()
+		require.NoError(t, err)
+
+		env, err := cii.Parse(data)
+		require.NoError(t, err)
+		out, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		require.NotNil(t, out.Ordering)
+		require.NotNil(t, out.Ordering.Issuer)
+		assert.Equal(t, "Billing Service Provider SL", out.Ordering.Issuer.Name)
+	})
+}

--- a/settlement.go
+++ b/settlement.go
@@ -19,6 +19,7 @@ type Settlement struct {
 	CreditorRefID      string                `xml:"ram:CreditorReferenceID,omitempty"`
 	PaymentReference   string                `xml:"ram:PaymentReference,omitempty"`
 	Currency           string                `xml:"ram:InvoiceCurrencyCode"`
+	Invoicer           *Party                `xml:"ram:InvoicerTradeParty,omitempty"`
 	Payee              *Party                `xml:"ram:PayeeTradeParty,omitempty"`
 	PaymentMeans       []*PaymentMeans       `xml:"ram:SpecifiedTradeSettlementPaymentMeans"`
 	Tax                []*Tax                `xml:"ram:ApplicableTradeTax"`
@@ -169,6 +170,9 @@ func newSettlement(inv *bill.Invoice, ctx Context) (*Settlement, error) {
 			rd.IssueDate = &FormattedIssueDate{DateFormat: d}
 		}
 		stlm.ReferencedDocument = []*ReferencedDocument{rd}
+	}
+	if inv.Ordering != nil && inv.Ordering.Issuer != nil {
+		stlm.Invoicer = newParty(inv.Ordering.Issuer, ctx)
 	}
 	if inv.Payment != nil && inv.Payment.Payee != nil {
 		stlm.Payee = newPayee(inv.Payment.Payee, ctx)


### PR DESCRIPTION
## What

Maps GOBL `bill.Ordering.Issuer` ⇄ CII `/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:InvoicerTradeParty`, in both convert and parse directions.

The ordering issuer represents *a third party responsible for issuing the document on behalf of the supplier, but not liable for tax* — CII models this as `InvoicerTradeParty`. This is the CII counterpart of the UBL `ServiceProviderParty` mapping (invopop/gobl.ubl#117).

## Changes

- **`settlement.go`** — added the `Invoicer *Party` field to `Settlement`, positioned before `Payee` per the `ApplicableHeaderTradeSettlement` element sequence (`InvoicerTradeParty` precedes `PayeeTradeParty`). `newSettlement` maps `Ordering.Issuer` via `newParty` (full party: name, address, tax registration, contact).
- **`ordering_parse.go`** — reverse mapping: `Settlement.Invoicer` → `Ordering.Issuer` via `goblNewParty`; added `Issuer` to `goblOrderingHasData`.
- **`ordering_test.go`** — new `TestOrderingIssuer` (convert + XML round-trip).

## Notes

Emitted unconditionally (not gated by profile), consistent with the UBL side. `InvoicerTradeParty` is an EN16931-extended element, so strict CII profiles may warn on it — an accepted trade-off.

## Tests

`go test ./...` green; `golangci-lint run ./...` clean. New convert + round-trip coverage in `TestOrderingIssuer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)