### PR TITLE
fix: map BT-19 buyer accounting reference to ReceivableSpecifiedTradeAccountingAccount

### DIFF
--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -30,6 +30,11 @@ func goblNewOrdering(in *Invoice) (*bill.Ordering, error) {
 		ord.Issuer = goblNewParty(tr.Settlement.Invoicer)
 	}
 
+	// BT-19: Buyer accounting reference
+	if tr.Settlement.AccountingAccount != nil && tr.Settlement.AccountingAccount.ID != "" {
+		ord.Cost = cbc.Code(tr.Settlement.AccountingAccount.ID)
+	}
+
 	if tr.Agreement.Sales != nil {
 		ord.Sales = []*org.DocumentRef{
 			{

--- a/ordering_parse_test.go
+++ b/ordering_parse_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +35,16 @@ func TestParseCtoGOrdering(t *testing.T) {
 		assert.Equal(t, "2014-08-31", inv.Ordering.Period.End.String(), "OrderingPeriod end date should match")
 	})
 
+}
+
+func TestParseCtoGOrderingCost(t *testing.T) {
+	e, err := parseInvoiceFrom(t, "CII_example2.xml")
+	require.NoError(t, err)
+
+	inv, ok := e.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotNil(t, inv.Ordering, "Ordering should not be nil")
+	// BT-19: Buyer accounting reference
+	assert.Equal(t, cbc.Code("Project cost code 123"), inv.Ordering.Cost)
 }

--- a/ordering_test.go
+++ b/ordering_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/invopop/gobl"
 	cii "github.com/invopop/gobl.cii"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,5 +52,45 @@ func TestOrderingIssuer(t *testing.T) {
 		require.NotNil(t, out.Ordering)
 		require.NotNil(t, out.Ordering.Issuer)
 		assert.Equal(t, "Billing Service Provider SL", out.Ordering.Issuer.Name)
+	})
+}
+
+func TestOrderingCost(t *testing.T) {
+	// costEnv loads a complete invoice and attaches a buyer accounting reference (BT-19).
+	costEnv := func(t *testing.T) *gobl.Envelope {
+		t.Helper()
+		env := loadEnvelope(t, "en16931/invoice-de-de.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		if inv.Ordering == nil {
+			inv.Ordering = &bill.Ordering{}
+		}
+		inv.Ordering.Cost = "1287:65464"
+		require.NoError(t, env.Calculate())
+		return env
+	}
+
+	t.Run("maps ordering cost to ReceivableSpecifiedTradeAccountingAccount", func(t *testing.T) {
+		doc, err := cii.ConvertInvoice(costEnv(t))
+		require.NoError(t, err)
+
+		acc := doc.Transaction.Settlement.AccountingAccount
+		require.NotNil(t, acc, "AccountingAccount should be set from ordering.cost")
+		assert.Equal(t, "1287:65464", acc.ID)
+	})
+
+	t.Run("round-trips accounting cost back to GOBL ordering", func(t *testing.T) {
+		doc, err := cii.ConvertInvoice(costEnv(t))
+		require.NoError(t, err)
+		data, err := doc.Bytes()
+		require.NoError(t, err)
+
+		env, err := cii.Parse(data)
+		require.NoError(t, err)
+		out, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		require.NotNil(t, out.Ordering)
+		assert.Equal(t, cbc.Code("1287:65464"), out.Ordering.Cost)
 	})
 }

--- a/settlement.go
+++ b/settlement.go
@@ -28,6 +28,7 @@ type Settlement struct {
 	PaymentTerms       []*Terms              `xml:"ram:SpecifiedTradePaymentTerms,omitempty"`
 	Summary            *Summary              `xml:"ram:SpecifiedTradeSettlementHeaderMonetarySummation"`
 	ReferencedDocument []*ReferencedDocument `xml:"ram:InvoiceReferencedDocument,omitempty"`
+	AccountingAccount  *AccountingAccount    `xml:"ram:ReceivableSpecifiedTradeAccountingAccount,omitempty"`
 	Advance            []*Advance            `xml:"ram:SpecifiedAdvancePayment,omitempty"`
 }
 
@@ -173,6 +174,12 @@ func newSettlement(inv *bill.Invoice, ctx Context) (*Settlement, error) {
 	}
 	if inv.Ordering != nil && inv.Ordering.Issuer != nil {
 		stlm.Invoicer = newParty(inv.Ordering.Issuer, ctx)
+	}
+	// BT-19: Buyer accounting reference
+	if inv.Ordering != nil && inv.Ordering.Cost != "" {
+		stlm.AccountingAccount = &AccountingAccount{
+			ID: inv.Ordering.Cost.String(),
+		}
 	}
 	if inv.Payment != nil && inv.Payment.Payee != nil {
 		stlm.Payee = newPayee(inv.Payment.Payee, ctx)


### PR DESCRIPTION
## Summary
- Map GOBL `ordering.cost` to CII `ram:ReceivableSpecifiedTradeAccountingAccount/ram:ID` (BT-19), and back.
- Field previously didn't exist on `Settlement` at all — the header-level BT-19 was never emitted or parsed (the line-level equivalent, BT-133, already worked).

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` clean