### PR TITLE
fix: pin FR regime on parsed CDAR payments so amount-less CDVs import

### DIFF
--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -260,6 +261,14 @@ func goblPaymentFromCDAR(cdar *CDAR, r routing) (*bill.Payment, error) {
 	}
 	pmt := &bill.Payment{}
 	pmt.SetAddons(flow6.V1)
+	// A Flow 6 CDV is a French domestic exchange, so pin the FR regime. The
+	// parties carry only a SIREN (no tax ID), leaving GOBL nothing else to
+	// derive a regime — and hence a currency — from when the CDAR omits the
+	// amount characteristics entirely (some platforms emit a 211 with no
+	// MPA). With the regime set the currency defaults to EUR and the
+	// document parses; the missing amount then surfaces as a validation
+	// error ("amount must be positive") instead of aborting calculation.
+	pmt.SetRegime(l10n.FR.Tax())
 
 	code := cbc.Code(cdarProcessCode(cdar))
 	switch code {

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -261,13 +261,9 @@ func goblPaymentFromCDAR(cdar *CDAR, r routing) (*bill.Payment, error) {
 	}
 	pmt := &bill.Payment{}
 	pmt.SetAddons(flow6.V1)
-	// A Flow 6 CDV is a French domestic exchange, so pin the FR regime. The
-	// parties carry only a SIREN (no tax ID), leaving GOBL nothing else to
-	// derive a regime — and hence a currency — from when the CDAR omits the
-	// amount characteristics entirely (some platforms emit a 211 with no
-	// MPA). With the regime set the currency defaults to EUR and the
-	// document parses; the missing amount then surfaces as a validation
-	// error ("amount must be positive") instead of aborting calculation.
+	// Pin the FR regime so the currency can default to EUR even when the
+	// CDAR carries no amount characteristics (the parties have no tax ID
+	// to derive it from).
 	pmt.SetRegime(l10n.FR.Tax())
 
 	code := cbc.Code(cdarProcessCode(cdar))

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -261,9 +261,6 @@ func goblPaymentFromCDAR(cdar *CDAR, r routing) (*bill.Payment, error) {
 	}
 	pmt := &bill.Payment{}
 	pmt.SetAddons(flow6.V1)
-	// Pin the FR regime so the currency can default to EUR even when the
-	// CDAR carries no amount characteristics (the parties have no tax ID
-	// to derive it from).
 	pmt.SetRegime(l10n.FR.Tax())
 
 	code := cbc.Code(cdarProcessCode(cdar))

--- a/cdar_status_test.go
+++ b/cdar_status_test.go
@@ -487,15 +487,10 @@ func TestCDARPaymentPartialRoundTrip(t *testing.T) {
 	assert.Equal(t, "250.00", out.Lines[0].Due.String())
 }
 
-// TestCDARPaymentNoAmount covers a 211 (Paiement transmis) CDV seen in
-// the wild whose SpecifiedDocumentStatus carries no
-// SpecifiedDocumentCharacteristic at all — no MPA amount, and therefore
-// no currency either. The spec only mandates the amount characteristic
-// for a 212 (BR-FR-CDV-14), so the document must still parse: the FR
-// regime pinned by the parser lets GOBL default the currency to EUR,
-// and the absent amount surfaces as a validation error on the envelope
-// (stored as invalid) rather than fabricating a value or aborting
-// calculation with "currency: required, unable to determine".
+// TestCDARPaymentNoAmount covers a 211 (Paiement transmis) CDV with no
+// SpecifiedDocumentCharacteristic — no MPA amount, no currency. It must
+// still parse (currency defaults to EUR via the FR regime), with the
+// missing amount surfacing as a validation error instead.
 func TestCDARPaymentNoAmount(t *testing.T) {
 	data := []byte(`<rsm:CrossDomainAcknowledgementAndResponse xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossDomainAcknowledgementAndResponse:100">
 	<rsm:ExchangedDocumentContext>

--- a/cdar_status_test.go
+++ b/cdar_status_test.go
@@ -565,7 +565,7 @@ func TestCDARPaymentNoAmount(t *testing.T) {
 	require.True(t, ok, "211 parses as a payment")
 	assert.Equal(t, bill.PaymentTypeAdvice, pmt.Type)
 	assert.Equal(t, cbc.Code("211"), pmt.Ext.Get(flow6.ExtKeyStatus))
-	assert.Equal(t, "FR", pmt.Regime.Country.String(),
+	assert.Equal(t, "FR", pmt.Country.String(),
 		"parser pins the FR regime")
 	assert.Equal(t, currency.EUR, pmt.Currency,
 		"currency defaults to EUR via the FR regime")

--- a/cdar_status_test.go
+++ b/cdar_status_test.go
@@ -487,6 +487,100 @@ func TestCDARPaymentPartialRoundTrip(t *testing.T) {
 	assert.Equal(t, "250.00", out.Lines[0].Due.String())
 }
 
+// TestCDARPaymentNoAmount covers a 211 (Paiement transmis) CDV seen in
+// the wild whose SpecifiedDocumentStatus carries no
+// SpecifiedDocumentCharacteristic at all — no MPA amount, and therefore
+// no currency either. The spec only mandates the amount characteristic
+// for a 212 (BR-FR-CDV-14), so the document must still parse: the FR
+// regime pinned by the parser lets GOBL default the currency to EUR,
+// and the absent amount surfaces as a validation error on the envelope
+// (stored as invalid) rather than fabricating a value or aborting
+// calculation with "currency: required, unable to determine".
+func TestCDARPaymentNoAmount(t *testing.T) {
+	data := []byte(`<rsm:CrossDomainAcknowledgementAndResponse xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossDomainAcknowledgementAndResponse:100">
+	<rsm:ExchangedDocumentContext>
+		<ram:BusinessProcessSpecifiedDocumentContextParameter>
+			<ram:ID>REGULATED</ram:ID>
+		</ram:BusinessProcessSpecifiedDocumentContextParameter>
+		<ram:GuidelineSpecifiedDocumentContextParameter>
+			<ram:ID>urn.cpro.gouv.fr:1p0:CDV:invoice</ram:ID>
+		</ram:GuidelineSpecifiedDocumentContextParameter>
+	</rsm:ExchangedDocumentContext>
+	<rsm:ExchangedDocument>
+		<ram:ID>d6e83535-452d-470a-8673-62708e82732a</ram:ID>
+		<ram:Name>F202500003_04-CDV-211_Paiement_transmis</ram:Name>
+		<ram:IssueDateTime>
+			<udt:DateTimeString format="204">20260805200314</udt:DateTimeString>
+		</ram:IssueDateTime>
+		<ram:SenderTradeParty>
+			<ram:RoleCode>WK</ram:RoleCode>
+		</ram:SenderTradeParty>
+		<ram:IssuerTradeParty>
+			<ram:GlobalID schemeID="0002">200000008</ram:GlobalID>
+			<ram:RoleCode>BY</ram:RoleCode>
+		</ram:IssuerTradeParty>
+		<ram:RecipientTradeParty>
+			<ram:GlobalID schemeID="0002">100000009</ram:GlobalID>
+			<ram:Name>VENDEUR</ram:Name>
+			<ram:RoleCode>SE</ram:RoleCode>
+			<ram:URIUniversalCommunication>
+				<ram:URIID schemeID="0225">100000009</ram:URIID>
+			</ram:URIUniversalCommunication>
+		</ram:RecipientTradeParty>
+	</rsm:ExchangedDocument>
+	<rsm:AcknowledgementDocument>
+		<ram:MultipleReferencesIndicator>
+			<udt:Indicator>false</udt:Indicator>
+		</ram:MultipleReferencesIndicator>
+		<ram:TypeCode>23</ram:TypeCode>
+		<ram:IssueDateTime>
+			<udt:DateTimeString format="204">20260805200314</udt:DateTimeString>
+		</ram:IssueDateTime>
+		<ram:ReferenceReferencedDocument>
+			<ram:IssuerAssignedID>F202500003</ram:IssuerAssignedID>
+			<ram:StatusCode>47</ram:StatusCode>
+			<ram:TypeCode>380</ram:TypeCode>
+			<ram:ReceiptDateTime>
+				<udt:DateTimeString format="204">20260805200314</udt:DateTimeString>
+			</ram:ReceiptDateTime>
+			<ram:FormattedIssueDateTime>
+				<qdt:DateTimeString format="102">20260720</qdt:DateTimeString>
+			</ram:FormattedIssueDateTime>
+			<ram:ProcessConditionCode>211</ram:ProcessConditionCode>
+			<ram:ProcessCondition>Paiement_transmis</ram:ProcessCondition>
+			<ram:IssuerTradeParty>
+				<ram:GlobalID schemeID="0002">100000009</ram:GlobalID>
+			</ram:IssuerTradeParty>
+			<ram:SpecifiedDocumentStatus>
+				<ram:SequenceNumeric>4</ram:SequenceNumeric>
+			</ram:SpecifiedDocumentStatus>
+		</ram:ReferenceReferencedDocument>
+	</rsm:AcknowledgementDocument>
+</rsm:CrossDomainAcknowledgementAndResponse>`)
+
+	env, err := cii.Parse(data)
+	require.NoError(t, err, "an amount-less 211 must still produce an envelope")
+
+	pmt, ok := env.Extract().(*bill.Payment)
+	require.True(t, ok, "211 parses as a payment")
+	assert.Equal(t, bill.PaymentTypeAdvice, pmt.Type)
+	assert.Equal(t, cbc.Code("211"), pmt.Ext.Get(flow6.ExtKeyStatus))
+	assert.Equal(t, "FR", pmt.Regime.Country.String(),
+		"parser pins the FR regime")
+	assert.Equal(t, currency.EUR, pmt.Currency,
+		"currency defaults to EUR via the FR regime")
+
+	require.Len(t, pmt.Lines, 1)
+	assert.True(t, pmt.Lines[0].Amount.IsZero(), "no amount is invented")
+	require.NotNil(t, pmt.Lines[0].Document)
+	assert.Equal(t, cbc.Code("F202500003"), pmt.Lines[0].Document.Code)
+
+	// The missing amount makes the document invalid, not unparseable.
+	err = env.Validate()
+	require.Error(t, err, "zero amount must fail validation")
+	assert.Contains(t, err.Error(), "amount")
+}
+
 // TestCDARPaymentPPFEncaissement covers the PPF (einvoicingF2) profile
 // fields that live 0654 rejections flagged on a 212: the cashed amount
 // must be split by VAT rate (MDT-215/MDT-224), and the document must

--- a/test/data/parse/out/UC1_F202500003_06-CDV-211_Paiement_transmis.json
+++ b/test/data/parse/out/UC1_F202500003_06-CDV-211_Paiement_transmis.json
@@ -4,13 +4,14 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "27b42f9ade172a1b90cb06e96371923594fd680d77f9a06bf408605a3eb9957d"
+			"val": "baaa43e9f8b54dff31845298bc081dce066bdb2c36ae4fa5ee843b26f89a71a8"
 		},
-		"from": "iso6523-actorid-upis::0225:200000008_STATUTS",
-		"to": "iso6523-actorid-upis::0225:100000009_STATUTS"
+		"from": "iso6523-actorid-upis::0225:100000009_STATUTS",
+		"to": "iso6523-actorid-upis::0225:200000008_STATUTS"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/payment",
+		"$regime": "FR",
 		"$addons": [
 			"fr-ctc-flow6-v1"
 		],

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee.json
@@ -4,13 +4,14 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a22ec36515fdb916226a654d2fcb1b441e7ef9b0ddc5a48caf3a9f9b30a498f4"
+			"val": "17e7251d4faa23ac075238b12e16385b325a4cb89f5063a159c48ee30f5f2ccb"
 		},
 		"from": "iso6523-actorid-upis::0225:100000009_STATUTS",
-		"to": "iso6523-actorid-upis::0225:200000008"
+		"to": "iso6523-actorid-upis::0225:200000008_STATUTS"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/payment",
+		"$regime": "FR",
 		"$addons": [
 			"fr-ctc-flow6-v1"
 		],

--- a/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
+++ b/test/data/parse/out/UC1_F202500003_07-CDV-212_Encaissee_POUR_PPF.json
@@ -4,12 +4,14 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bf35f531116485ef683f9d1d9ba48a889885d5b802ce5a85d7027616c832a7fb"
+			"val": "0795d5dd5cf1bde38878cfe675be831a6949c13d12b9318bb13a3d6688f6e099"
 		},
-		"from": "iso6523-actorid-upis::0225:100000009_STATUTS"
+		"from": "iso6523-actorid-upis::0225:100000009_STATUTS",
+		"to": "iso6523-actorid-upis::0225:200000008_STATUTS"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/payment",
+		"$regime": "FR",
 		"$addons": [
 			"fr-ctc-flow6-v1"
 		],


### PR DESCRIPTION
## Problem

A 211 (*Paiement transmis*) CDV received in production carried no `SpecifiedDocumentCharacteristic` at all — no MPA amount, and therefore no currency:

```xml
<ram:ProcessConditionCode>211</ram:ProcessConditionCode>
<ram:ProcessCondition>Paiement_transmis</ram:ProcessCondition>
...
<ram:SpecifiedDocumentStatus>
  <ram:SequenceNumeric>4</ram:SequenceNumeric>
</ram:SpecifiedDocumentStatus>
```

The spec only mandates the amount characteristic for a 212 (BR-FR-CDV-14), so this document violates no published CDV rule — yet `cii.Parse` aborted the whole envelope with `currency: required, unable to determine`. CDAR parties carry only a SIREN identity (no tax ID), leaving GOBL nothing to derive a regime — and hence a default currency — from.

## Fix

A Flow 6 CDV is by definition a French domestic exchange, so `goblPaymentFromCDAR` now pins the FR regime (`pmt.SetRegime(l10n.FR.Tax())`) on the parsed `bill.Payment`. From there:

- the currency defaults to **EUR through GOBL's standard regime mechanism** — no hardcoded fallback;
- **no amount is fabricated** — the line amount stays zero exactly as the wire document reported nothing;
- the missing amount surfaces as a **validation error** (`GOBL-BILL-PAYMENTLINE-04: amount must be positive`), so receivers can store the envelope as invalid (e.g. via `AllowInvalid`) instead of being unable to represent the document at all.

## Notes

- New regression test `TestCDARPaymentNoAmount` reproduces the production document (identifiers swapped for the UC1 spec-sample ones).
- Payment parse goldens regenerated: they gain `$regime: "FR"` and also pick up the head From/To direction fix from #64 that predated them (the golden comparison only checks `doc`, so they had drifted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)