### PR TITLE
feat: support negative payments (refunds) in CDAR conversion

### DIFF
--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -183,8 +183,6 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 	// When the payment line carries a tax breakdown, emit one
 	// characteristic per distinct rate (gross amount + percentage);
 	// otherwise fall back to a single amount-only characteristic.
-	// A refund line reverses the flow of funds: the CDV carries the sign
-	// on the amounts themselves, so emit them negated.
 	if split := newCDARVATSplitCharacteristics(condition, line, pmt.Currency); len(split) > 0 {
 		ds.SpecifiedDocumentCharacteristics = split
 	} else {

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -183,11 +183,17 @@ func newCDARPaymentAcknowledgement(pmt *bill.Payment, line *bill.PaymentLine, ac
 	// When the payment line carries a tax breakdown, emit one
 	// characteristic per distinct rate (gross amount + percentage);
 	// otherwise fall back to a single amount-only characteristic.
+	// A refund line reverses the flow of funds: the CDV carries the sign
+	// on the amounts themselves, so emit them negated.
 	if split := newCDARVATSplitCharacteristics(condition, line, pmt.Currency); len(split) > 0 {
 		ds.SpecifiedDocumentCharacteristics = split
 	} else {
+		amount := line.Amount
+		if line.Refund {
+			amount = amount.Negate()
+		}
 		ds.SpecifiedDocumentCharacteristics = append(ds.SpecifiedDocumentCharacteristics,
-			newCDARAmountCharacteristic(condition, line.Amount, pmt.Currency))
+			newCDARAmountCharacteristic(condition, amount, pmt.Currency))
 	}
 	if line.Due != nil && condition != flow6.ConditionAmountRemaining {
 		ds.SpecifiedDocumentCharacteristics = append(ds.SpecifiedDocumentCharacteristics,
@@ -229,6 +235,9 @@ func newCDARVATSplitCharacteristics(typeCode cbc.Code, line *bill.PaymentLine, c
 				pct = rt.Percent.Amount().Rescale(2).String()
 			}
 			gross := rt.Base.Add(rt.Amount)
+			if line.Refund {
+				gross = gross.Negate()
+			}
 			chars = append(chars, &CDARDocumentCharacteristic{
 				TypeCode:     typeCode.String(),
 				ValueAmount:  &CDARValueAmount{Value: gross.String(), CurrencyID: cur.String()},
@@ -325,7 +334,11 @@ func goblPaymentFromCDAR(cdar *CDAR, r routing) (*bill.Payment, error) {
 				pmt.Supplier = goblPartyFromCDAR(ref.IssuerTradeParty)
 			}
 			line := goblPaymentLineFromCDAR(pmt, ref)
-			total = total.Add(line.Amount)
+			a := line.Amount
+			if line.Refund {
+				a = a.Negate()
+			}
+			total = total.MatchPrecision(a).Add(a)
 			pmt.Lines = append(pmt.Lines, line)
 		}
 	}
@@ -409,6 +422,20 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 		}
 	}
 	if cashed != nil {
+		// A negative cashed amount is a refund: GOBL keeps amounts
+		// positive and carries the direction on the Refund flag, so flip
+		// the line and the recovered tax breakdown along with it.
+		if cashed.IsNegative() {
+			line.Refund = true
+			*cashed = cashed.Negate()
+			for _, rt := range vatRates {
+				rt.Base = rt.Base.Negate()
+				rt.Amount = rt.Amount.Negate()
+			}
+			if vatSum != nil {
+				*vatSum = vatSum.Negate()
+			}
+		}
 		line.Amount = *cashed
 	}
 	if len(vatRates) > 0 && vatSum != nil {

--- a/cdar_payment.go
+++ b/cdar_payment.go
@@ -422,9 +422,6 @@ func goblPaymentLineFromCDAR(pmt *bill.Payment, ref *CDARReferencedDocument) *bi
 		}
 	}
 	if cashed != nil {
-		// A negative cashed amount is a refund: GOBL keeps amounts
-		// positive and carries the direction on the Refund flag, so flip
-		// the line and the recovered tax breakdown along with it.
 		if cashed.IsNegative() {
 			line.Refund = true
 			*cashed = cashed.Negate()

--- a/cdar_payment_split_test.go
+++ b/cdar_payment_split_test.go
@@ -3,6 +3,7 @@ package cii_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl"
 	cii "github.com/invopop/gobl.cii"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
@@ -157,4 +158,70 @@ func TestCDARPaymentAmountDerivedFromRates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "820.00", out.Lines[0].Amount.String(),
 		"parsed Amount is the Σ of grosses, not the bogus input")
+}
+
+// TestCDARPaymentRefundRoundTrip covers negative payments: a line with
+// Refund set emits its CDV amounts negated, and a CDV with negative
+// cashed amounts parses back into a positive Amount with Refund set.
+func TestCDARPaymentRefundRoundTrip(t *testing.T) {
+	t.Run("vat split", func(t *testing.T) {
+		pmt := buildSyntheticPayment(t, num.Amount{})
+		pmt.Lines[0].Refund = true
+		pmt.Lines[0].Tax = &tax.Total{
+			Categories: []*tax.CategoryTotal{{Code: tax.CategoryVAT, Rates: []*tax.RateTotal{
+				vatRate(amt(50000), amt(10000), pct(20)), // gross 600.00
+			}}},
+		}
+
+		cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+		require.NoError(t, err)
+		chars := cdar.AcknowledgementDocuments[0].ReferenceReferencedDocument[0].
+			SpecifiedDocumentStatuses[0].SpecifiedDocumentCharacteristics
+		require.Len(t, chars, 1)
+		assert.Equal(t, "-600.00", chars[0].ValueAmount.Value, "refund gross is negated")
+		assert.Equal(t, rate20, chars[0].ValuePercent)
+
+		data, err := cdar.Bytes()
+		require.NoError(t, err)
+		out, err := cii.ParseCDARPayment(data)
+		require.NoError(t, err)
+		require.Len(t, out.Lines, 1)
+		assert.True(t, out.Lines[0].Refund, "negative cashed amount parses as a refund")
+		assert.Equal(t, grossStd, out.Lines[0].Amount.String(), "Amount stays positive")
+
+		require.NotNil(t, out.Lines[0].Tax)
+		rates := out.Lines[0].Tax.Categories[0].Rates
+		require.Len(t, rates, 1)
+		assert.Equal(t, "500.00", rates[0].Base.String(), "recovered base is positive")
+		assert.Equal(t, "100.00", rates[0].Amount.String(), "recovered VAT is positive")
+
+		require.Len(t, out.Methods, 1)
+		assert.Equal(t, "-600.00", out.Methods[0].Amount.String(),
+			"synthesized method carries the negated total")
+
+		env, err := gobl.Envelop(out)
+		require.NoError(t, err, "refund payment must calculate")
+		require.NoError(t, env.Validate(), "refund payment must pass flow6 validation")
+	})
+
+	t.Run("amount only", func(t *testing.T) {
+		pmt := buildSyntheticPayment(t, num.Amount{})
+		pmt.Lines[0].Refund = true
+		pmt.Lines[0].Tax = nil
+
+		cdar, err := cii.NewCDARFromPayment(pmt, cii.ContextCDARFlow6)
+		require.NoError(t, err)
+		chars := cdar.AcknowledgementDocuments[0].ReferenceReferencedDocument[0].
+			SpecifiedDocumentStatuses[0].SpecifiedDocumentCharacteristics
+		require.Len(t, chars, 1)
+		assert.Equal(t, "-500.00", chars[0].ValueAmount.Value, "refund amount is negated")
+
+		data, err := cdar.Bytes()
+		require.NoError(t, err)
+		out, err := cii.ParseCDARPayment(data)
+		require.NoError(t, err)
+		require.Len(t, out.Lines, 1)
+		assert.True(t, out.Lines[0].Refund)
+		assert.Equal(t, "500.00", out.Lines[0].Amount.String())
+	})
 }

--- a/docs/cdar-mapping.md
+++ b/docs/cdar-mapping.md
@@ -203,6 +203,10 @@ Special rule (BR-FR-CDV-14): a `paid` (212) status line MUST carry a
 characteristic with `TypeCode = MEN` (Montant Encaissé) and
 `Amount.{Value, Currency}` populated.
 
+Refunds: a payment line with `Refund` set emits its MEN / MPA amounts
+(and per-rate grosses) negated in the CDV; parsing maps negative cashed
+amounts back to a positive `Amount` with `Refund = true`.
+
 When a Reason and a Characteristic are linked by their CDAR ReasonCode
 the writer keeps them in the same `SpecifiedDocumentStatus` entry; the
 `Characteristic.ReasonCode` field, when set, must match the


### PR DESCRIPTION
Adds refund (negative payment) support to the CDAR payment mapping using `bill.PaymentLine.Refund`.

## Generation

A line with `Refund: true` emits its CDV amounts negated:
- the amount-only MEN / MPA characteristic carries the negated `line.Amount`;
- the per-rate VAT-split characteristics (MDT-215) carry each rate's negated gross.

The RAP (reste à payer) remainder is left unsigned — it's its own quantity, not part of the reversed flow.

## Parsing

A negative cashed amount (MEN / MPA) parses back into GOBL's convention: positive `Amount` with `Refund = true`, and the tax breakdown recovered from MDT-224 percentages is flipped positive along with it. The synthesized payment-method record carries the signed total (refund lines subtract), now accumulated with matched precision so decimals aren't truncated.

## gobl.fr.ctc

Checked flow6 (v0.0.7): it imposes no sign or Refund constraints, so refund payments pass validation unchanged — no addon change needed. The round-trip test asserts a parsed refund envelope validates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)