### PR TITLE
Reference the German addon keys as constants

### DIFF
--- a/cii.go
+++ b/cii.go
@@ -10,8 +10,6 @@ import (
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl.fr.ctc/addon/flow2"
 	"github.com/invopop/gobl.fr.ctc/addon/flow6"
-	"github.com/invopop/gobl/addons/de/xrechnung"
-	"github.com/invopop/gobl/addons/de/zugferd"
 	"github.com/invopop/gobl/addons/eu/en16931"
 	"github.com/invopop/gobl/addons/fr/choruspro"
 	"github.com/invopop/gobl/addons/fr/facturx"
@@ -50,6 +48,14 @@ const (
 const (
 	guidelineIDEN16931V2017 = "urn:cen.eu:en16931:2017"
 	vesIDEN16931CII         = "eu.cen.en16931:cii:1.3.16"
+)
+
+// German addon keys. The addons themselves live in gobl.de.xinvoice;
+// naming the keys here avoids importing that module, which would be a
+// dependency cycle.
+const (
+	addonKeyXRechnung cbc.Key = "de-xrechnung-v3"
+	addonKeyZUGFeRD   cbc.Key = "de-zugferd-v2"
 )
 
 // Profile ID codes
@@ -142,7 +148,7 @@ var ContextPeppolFranceCIUSV1 = Context{
 var ContextZUGFeRDV2 = Context{
 	GuidelineID: guidelineIDEN16931V2017,
 	Version:     VersionD16B,
-	Addons:      []cbc.Key{zugferd.V2},
+	Addons:      []cbc.Key{addonKeyZUGFeRD},
 	VESID:       "de.zugferd:en16931:2.4",
 }
 
@@ -151,7 +157,7 @@ var ContextXRechnungV3 = Context{
 	GuidelineID: guidelineIDEN16931V2017 + "#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0",
 	BusinessID:  ProfileIDPeppolBilling,
 	Version:     VersionD16B,
-	Addons:      []cbc.Key{xrechnung.V3},
+	Addons:      []cbc.Key{addonKeyXRechnung},
 	VESID:       "de.xrechnung:cii:3.0.2",
 }
 

--- a/delivery.go
+++ b/delivery.go
@@ -3,7 +3,6 @@ package cii
 import (
 	"slices"
 
-	"github.com/invopop/gobl/addons/de/zugferd"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/org"
@@ -57,7 +56,7 @@ func newDelivery(inv *bill.Invoice) *Delivery {
 				}
 			}
 		}
-	} else if documentType := inv.Tax.Ext.Get(untdid.ExtKeyDocumentType); slices.Contains(inv.GetAddons(), zugferd.V2) && documentType.String() != "386" {
+	} else if documentType := inv.Tax.Ext.Get(untdid.ExtKeyDocumentType); slices.Contains(inv.GetAddons(), addonKeyZUGFeRD) && documentType.String() != "386" {
 		// Helper for Zugferd BR-FX-EN-04 rule in case delivery
 		// is not specified in the invoice (imported invoice)
 		// TODO: move logic to addon


### PR DESCRIPTION
Replaces the gobl/addons/de/... imports with local constants for de-xrechnung-v3 and de-zugferd-v2. Those addon packages are moving to gobl.de.xinvoice, and importing that module here would be a dependency cycle.

Affects the two German contexts and the ZUGFeRD branch in delivery.go (BR-FX-EN-04 handling), which also referenced the addon package. No behaviour change, and it is compatible with both the current GOBL core and the one that no longer ships the German addons — so it can be released ahead of that change.