### PR TITLE
feat: item attributes, line seller, contract reason, charge exemption codes

### DIFF
--- a/agreement.go
+++ b/agreement.go
@@ -13,7 +13,7 @@ type Agreement struct {
 	TaxRepresentative  *Party                `xml:"ram:SellerTaxRepresentativeTradeParty,omitempty"`
 	Sales              *IssuerID             `xml:"ram:SellerOrderReferencedDocument,omitempty"`
 	Purchase           *IssuerID             `xml:"ram:BuyerOrderReferencedDocument,omitempty"`
-	Contract           *IssuerID             `xml:"ram:ContractReferencedDocument,omitempty"`
+	Contract           *ContractReference    `xml:"ram:ContractReferencedDocument,omitempty"`
 	AdditionalDocument []*AdditionalDocument `xml:"ram:AdditionalReferencedDocument,omitempty"`
 	Project            *Project              `xml:"ram:SpecifiedProcurringProject,omitempty"`
 }
@@ -46,6 +46,12 @@ type IssuerID struct {
 	ID string `xml:"ram:IssuerAssignedID,omitempty"`
 }
 
+// ContractReference defines the structure of ContractReferencedDocument of the CII standard
+type ContractReference struct {
+	ID                string `xml:"ram:IssuerAssignedID,omitempty"`
+	ReferenceTypeCode string `xml:"ram:ReferenceTypeCode,omitempty"`
+}
+
 // prepareAgreement creates the ApplicableHeaderTradeAgreement part of a EN 16931 compliant invoice
 func (out *Invoice) addAgreement(inv *bill.Invoice, ctx Context) error {
 	out.Transaction.Agreement = new(Agreement)
@@ -73,9 +79,12 @@ func (out *Invoice) addAgreement(inv *bill.Invoice, ctx Context) error {
 			agmt.Seller = newParty(inv.Ordering.Seller, ctx)
 		}
 		if len(inv.Ordering.Contracts) > 0 {
-			c := inv.Ordering.Contracts[0].Code.String()
-			agmt.Contract = &IssuerID{
-				ID: c,
+			c := inv.Ordering.Contracts[0]
+			agmt.Contract = &ContractReference{
+				ID: c.Code.String(),
+			}
+			if c.Reason != "" {
+				agmt.Contract.ReferenceTypeCode = c.Reason
 			}
 		}
 		if len(inv.Ordering.Purchases) > 0 {

--- a/agreement_test.go
+++ b/agreement_test.go
@@ -3,6 +3,8 @@ package cii_test
 import (
 	"testing"
 
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/bill"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,5 +31,26 @@ func TestNewAgreement(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "PO4711", doc.Transaction.Agreement.BuyerReference)
 		assert.Equal(t, "2013-05", doc.Transaction.Agreement.Contract.ID)
+		assert.Equal(t, "MARCHE", doc.Transaction.Agreement.Contract.ReferenceTypeCode)
 	})
+}
+
+func TestContractReferenceTypeRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-complete.json")
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.Transaction.Agreement.Contract)
+	assert.Equal(t, "MARCHE", doc.Transaction.Agreement.Contract.ReferenceTypeCode)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotEmpty(t, parsedInv.Ordering.Contracts)
+	assert.Equal(t, "MARCHE", parsedInv.Ordering.Contracts[0].Reason)
 }

--- a/allowance_charge.go
+++ b/allowance_charge.go
@@ -3,6 +3,7 @@ package cii
 import (
 	"github.com/invopop/gobl/addons/eu/en16931"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/cef"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/tax"
 )
@@ -27,12 +28,16 @@ func newAllowanceCharges(inv *bill.Invoice) []*AllowanceCharge {
 	if inv.Charges == nil && inv.Discounts == nil {
 		return nil
 	}
+	var notes []*tax.Note
+	if inv.Tax != nil {
+		notes = inv.Tax.Notes
+	}
 	ac := make([]*AllowanceCharge, len(inv.Charges)+len(inv.Discounts))
 	for i, c := range inv.Charges {
-		ac[i] = newCharge(c)
+		ac[i] = newCharge(c, notes)
 	}
 	for i, d := range inv.Discounts {
-		ac[i+len(inv.Charges)] = newDiscount(d)
+		ac[i+len(inv.Charges)] = newDiscount(d, notes)
 	}
 	return ac
 }
@@ -51,7 +56,7 @@ func newLineAllowanceCharges(line *bill.Line) []*AllowanceCharge {
 	return ac
 }
 
-func newCharge(c *bill.Charge) *AllowanceCharge {
+func newCharge(c *bill.Charge, notes []*tax.Note) *AllowanceCharge {
 	ac := &AllowanceCharge{
 		ChargeIndicator: Indicator{Value: true},
 		Amount:          c.Amount.Rescale(2).String(),
@@ -73,11 +78,12 @@ func newCharge(c *bill.Charge) *AllowanceCharge {
 	}
 	if c.Taxes != nil {
 		ac.Tax = makeTaxCategory(c.Taxes[0])
+		applyExemptionReason(ac.Tax, c.Taxes[0], notes)
 	}
 	return ac
 }
 
-func newDiscount(d *bill.Discount) *AllowanceCharge {
+func newDiscount(d *bill.Discount, notes []*tax.Note) *AllowanceCharge {
 	ac := &AllowanceCharge{
 		ChargeIndicator: Indicator{Value: false},
 		Amount:          d.Amount.Rescale(2).String(),
@@ -97,6 +103,7 @@ func newDiscount(d *bill.Discount) *AllowanceCharge {
 	}
 	if d.Taxes != nil {
 		ac.Tax = makeTaxCategory(d.Taxes[0])
+		applyExemptionReason(ac.Tax, d.Taxes[0], notes)
 	}
 
 	return ac
@@ -151,4 +158,17 @@ func makeTaxCategory(t *tax.Combo) *Tax {
 		}
 	}
 	return c
+}
+
+// applyExemptionReason sets the exemption reason code and text on an
+// AllowanceCharge's own tax category. Only valid at the document (and CII
+// AllowanceCharge) level - line-level ApplicableTradeTax does not permit
+// ram:ExemptionReasonCode in at least the Factur-X profile.
+func applyExemptionReason(c *Tax, t *tax.Combo, notes []*tax.Note) {
+	if t.Ext.Has(cef.ExtKeyVATEX) {
+		c.ExemptionReasonCode = t.Ext.Get(cef.ExtKeyVATEX).String()
+	}
+	if note := findTaxNote(notes, t.Category, t.Ext); note != nil {
+		c.ExemptionReason = note.Text
+	}
 }

--- a/allowance_charge_test.go
+++ b/allowance_charge_test.go
@@ -3,6 +3,10 @@ package cii_test
 import (
 	"testing"
 
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +26,35 @@ func TestNewAllowanceCharges(t *testing.T) {
 		assert.Equal(t, "88", doc.Transaction.Settlement.AllowanceCharges[1].ReasonCode)
 		assert.Equal(t, "10.00", doc.Transaction.Settlement.AllowanceCharges[1].Amount)
 		assert.Equal(t, "Promotion discount", doc.Transaction.Settlement.AllowanceCharges[1].Reason)
+	})
+
+	t.Run("discount exemption reason matches header category", func(t *testing.T) {
+		env := loadEnvelope(t, "en16931/invoice-exempt.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Discounts = append(inv.Discounts, &bill.Discount{
+			Reason: "Loyalty discount",
+			Amount: num.MakeAmount(500, 2),
+			Taxes:  tax.Set{inv.Lines[0].Taxes[0]},
+		})
+		require.NoError(t, env.Calculate())
+
+		doc, err := cii.ConvertInvoice(env)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, doc.Transaction.Settlement.AllowanceCharges)
+		ac := doc.Transaction.Settlement.AllowanceCharges[len(doc.Transaction.Settlement.AllowanceCharges)-1]
+		require.NotNil(t, ac.Tax)
+		assert.Equal(t, "VATEX-EU-132", ac.Tax.ExemptionReasonCode)
+
+		// Line-level ApplicableTradeTax must never carry ExemptionReasonCode:
+		// at least the Factur-X profile marks it as not used in that context.
+		for _, line := range doc.Transaction.Lines {
+			for _, lineTax := range line.TradeSettlement.ApplicableTradeTax {
+				assert.Empty(t, lineTax.ExemptionReasonCode)
+			}
+		}
 	})
 
 	t.Run("invoice-without-buyers-tax-id.json", func(t *testing.T) {

--- a/invoice.go
+++ b/invoice.go
@@ -132,7 +132,7 @@ func newInvoice(inv *bill.Invoice, context Context) (*Invoice, error) {
 func (out *Invoice) addTransaction(inv *bill.Invoice, ctx Context) error {
 	out.Transaction = new(Transaction)
 
-	if err := out.addLines(inv.Lines); err != nil {
+	if err := out.addLines(inv.Lines, ctx); err != nil {
 		return err
 	}
 	if err := out.addAgreement(inv, ctx); err != nil {

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -173,6 +173,9 @@ func goblParsePreceding(refs []*ReferencedDocument) ([]*org.DocumentRef, error) 
 		docRef := &org.DocumentRef{
 			Code: cbc.Code(ref.IssuerAssignedID),
 		}
+		if ref.TypeCode != "" {
+			docRef.Ext = docRef.Ext.Set(untdid.ExtKeyDocumentType, cbc.Code(ref.TypeCode))
+		}
 		if ref.IssueDate != nil && ref.IssueDate.DateFormat != nil {
 			refDate, err := parseDate(ref.IssueDate.DateFormat.Value)
 			if err != nil {

--- a/lines.go
+++ b/lines.go
@@ -28,6 +28,7 @@ type LineAgreement struct {
 	OrderReference      *LineOrderReference `xml:"ram:BuyerOrderReferencedDocument,omitempty"`
 	AdditionalReference *LineDocReference   `xml:"ram:AdditionalReferencedDocument,omitempty"`
 	NetPrice            *NetPrice           `xml:"ram:NetPriceProductTradePrice"`
+	ItemSellerParty     *Party              `xml:"ram:ItemSellerTradeParty,omitempty"`
 }
 
 // LineDocReference defines the structure of AdditionalReferencedDocument at line level
@@ -113,18 +114,18 @@ type Summation struct {
 	Amount string `xml:"ram:LineTotalAmount"`
 }
 
-func (out *Invoice) addLines(lines []*bill.Line) error {
+func (out *Invoice) addLines(lines []*bill.Line, ctx Context) error {
 	var Lines []*Line
 
 	for _, l := range lines {
-		Lines = append(Lines, newLine(l))
+		Lines = append(Lines, newLine(l, ctx))
 	}
 
 	out.Transaction.Lines = Lines
 	return nil
 }
 
-func newLine(l *bill.Line) *Line {
+func newLine(l *bill.Line, ctx Context) *Line {
 	if l.Item == nil {
 		return nil
 	}
@@ -159,10 +160,11 @@ func newLine(l *bill.Line) *Line {
 	if len(l.Notes) > 0 {
 		var notes []*Note
 		for _, n := range l.Notes {
-			notes = append(notes, &Note{
-				SubjectCode: n.Key.String(),
-				Content:     n.Text,
-			})
+			note := &Note{Content: n.Text}
+			if code := n.Ext.Get(untdid.ExtKeyTextSubject); code != "" {
+				note.SubjectCode = code.String()
+			}
+			notes = append(notes, note)
 		}
 		lineItem.LineDoc.Note = notes
 	}
@@ -191,6 +193,24 @@ func newLine(l *bill.Line) *Line {
 		}
 	}
 
+	if len(it.Attributes) > 0 {
+		for _, attr := range it.Attributes {
+			char := &Characteristic{Description: attr.Label}
+			switch {
+			case attr.Amount != nil:
+				// No CII element is available for a quantity+unit value
+				// (unlike UBL's ValueQuantity) - render as text.
+				char.Value = attr.Amount.String()
+				if attr.Unit != "" {
+					char.Value += " " + string(attr.Unit)
+				}
+			case attr.Text != "":
+				char.Value = attr.Text
+			}
+			lineItem.Product.Characteristics = append(lineItem.Product.Characteristics, char)
+		}
+	}
+
 	// BT-128: Invoice line object identifier
 	if l.Identifier != nil {
 		ref := &LineDocReference{
@@ -209,6 +229,10 @@ func newLine(l *bill.Line) *Line {
 		lineItem.Agreement.OrderReference = &LineOrderReference{
 			LineID: l.Order.String(),
 		}
+	}
+
+	if l.Seller != nil {
+		lineItem.Agreement.ItemSellerParty = newParty(l.Seller, ctx)
 	}
 
 	return lineItem

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -80,11 +80,9 @@ func goblNewLine(it *Line, taxMap map[string]*taxCategoryInfo) (*bill.Line, erro
 		}
 	}
 
-	if len(it.Product.Characteristics) > 0 {
-		l.Item.Meta = make(cbc.Meta)
-		for _, char := range it.Product.Characteristics {
-			key := formatKey(char.Description)
-			l.Item.Meta[key] = char.Value
+	for _, char := range it.Product.Characteristics {
+		if attr := goblItemAttribute(char); attr != nil {
+			l.Item.Attributes = append(l.Item.Attributes, attr)
 		}
 	}
 
@@ -163,6 +161,20 @@ func goblLineProduct(prod *Product, item *org.Item) {
 	}
 }
 
+// goblItemAttribute converts a CII ApplicableProductCharacteristic into a
+// GOBL org.Attribute. TypeCode isn't mapped: there's no corresponding slot
+// on org.Attribute for it alongside a text value. Unlike UBL, CII has no
+// element for a quantity+unit value, so it always round-trips as text.
+func goblItemAttribute(char *Characteristic) *org.Attribute {
+	if char.Description == "" || char.Value == "" {
+		return nil
+	}
+	return &org.Attribute{
+		Label: strings.TrimSpace(char.Description),
+		Text:  strings.TrimSpace(char.Value),
+	}
+}
+
 // goblLineNotes populates line notes from the CII line document.
 func goblLineNotes(lineDoc *LineDoc, l *bill.Line) {
 	if lineDoc == nil || len(lineDoc.Note) == 0 {
@@ -175,7 +187,7 @@ func goblLineNotes(lineDoc *LineDoc, l *bill.Line) {
 			n.Text = strings.TrimSpace(note.Content)
 		}
 		if note.SubjectCode != "" {
-			n.Key = cbc.Key(note.SubjectCode)
+			n.Ext = tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTextSubject: cbc.Code(note.SubjectCode)})
 		}
 		l.Notes = append(l.Notes, n)
 	}
@@ -198,6 +210,10 @@ func goblLineAgreement(ag *LineAgreement, l *bill.Line) {
 	// BT-132: Purchase order line reference
 	if ag.OrderReference != nil && ag.OrderReference.LineID != "" {
 		l.Order = cbc.Code(ag.OrderReference.LineID)
+	}
+
+	if ag.ItemSellerParty != nil {
+		l.Seller = goblNewParty(ag.ItemSellerParty)
 	}
 }
 

--- a/lines_test.go
+++ b/lines_test.go
@@ -3,6 +3,14 @@ package cii_test
 import (
 	"testing"
 
+	cii "github.com/invopop/gobl.cii"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +35,115 @@ func TestNewLines(t *testing.T) {
 		assert.Equal(t, "20241012", doc.Transaction.Lines[0].TradeSettlement.Period.End.DateFormat.Value)
 	})
 
+}
+
+func TestLineNoteSubjectCodeRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-de-de.json")
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	inv.Lines[0].Notes = []*org.Note{
+		{
+			Text: "Handle with care",
+			Ext:  tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTextSubject: "AAI"}),
+		},
+	}
+
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, doc.Transaction.Lines[0].LineDoc.Note)
+	note := doc.Transaction.Lines[0].LineDoc.Note[0]
+	assert.Equal(t, "Handle with care", note.Content)
+	assert.Equal(t, "AAI", note.SubjectCode)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotEmpty(t, parsedInv.Lines[0].Notes)
+	n := parsedInv.Lines[0].Notes[0]
+	assert.Equal(t, "Handle with care", n.Text)
+	assert.Equal(t, cbc.Code("AAI"), n.Ext.Get(untdid.ExtKeyTextSubject))
+}
+
+func TestItemAttributeRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-de-de.json")
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	weight := num.MakeAmount(25, 1) // 2.5
+	inv.Lines[0].Item.Attributes = []*org.Attribute{
+		{Label: "Color", Text: "Black"},
+		{Label: "Weight", Amount: &weight, Unit: "kg"},
+	}
+
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	require.Len(t, doc.Transaction.Lines[0].Product.Characteristics, 2)
+
+	char1 := doc.Transaction.Lines[0].Product.Characteristics[0]
+	assert.Equal(t, "Color", char1.Description)
+	assert.Equal(t, "Black", char1.Value)
+
+	// CII has no element for a quantity+unit value (unlike UBL's
+	// ValueQuantity), so it's rendered as plain text.
+	char2 := doc.Transaction.Lines[0].Product.Characteristics[1]
+	assert.Equal(t, "Weight", char2.Description)
+	assert.Equal(t, "2.5 kg", char2.Value)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.Len(t, parsedInv.Lines[0].Item.Attributes, 2)
+	assert.Equal(t, "Color", parsedInv.Lines[0].Item.Attributes[0].Label)
+	assert.Equal(t, "Black", parsedInv.Lines[0].Item.Attributes[0].Text)
+	assert.Equal(t, "Weight", parsedInv.Lines[0].Item.Attributes[1].Label)
+	assert.Equal(t, "2.5 kg", parsedInv.Lines[0].Item.Attributes[1].Text)
+}
+
+func TestLineSellerRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-de-de.json")
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	inv.Lines[0].Seller = &org.Party{
+		Identities: []*org.Identity{
+			{
+				Ext:  tax.ExtensionsOf(cbc.CodeMap{iso.ExtKeySchemeID: "0088"}),
+				Code: "1234567890128",
+			},
+		},
+	}
+
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.Transaction.Lines[0].Agreement.ItemSellerParty)
+	require.NotNil(t, doc.Transaction.Lines[0].Agreement.ItemSellerParty.GlobalID)
+	assert.Equal(t, "0088", doc.Transaction.Lines[0].Agreement.ItemSellerParty.GlobalID.SchemeID)
+	assert.Equal(t, "1234567890128", doc.Transaction.Lines[0].Agreement.ItemSellerParty.GlobalID.Value)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotNil(t, parsedInv.Lines[0].Seller)
+	require.Len(t, parsedInv.Lines[0].Seller.Identities, 1)
+	assert.Equal(t, cbc.Code("1234567890128"), parsedInv.Lines[0].Seller.Identities[0].Code)
+	assert.Equal(t, cbc.Code("0088"), parsedInv.Lines[0].Seller.Identities[0].Ext.Get(iso.ExtKeySchemeID))
 }

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -61,11 +61,13 @@ func goblNewOrdering(in *Invoice) (*bill.Ordering, error) {
 	}
 
 	if tr.Agreement.Contract != nil {
-		ord.Contracts = []*org.DocumentRef{
-			{
-				Code: cbc.Code(tr.Agreement.Contract.ID),
-			},
+		docRef := &org.DocumentRef{
+			Code: cbc.Code(tr.Agreement.Contract.ID),
 		}
+		if tr.Agreement.Contract.ReferenceTypeCode != "" {
+			docRef.Reason = tr.Agreement.Contract.ReferenceTypeCode
+		}
+		ord.Contracts = []*org.DocumentRef{docRef}
 	}
 
 	// Ordering period parsing

--- a/settlement.go
+++ b/settlement.go
@@ -85,6 +85,7 @@ type Advance struct {
 // ReferencedDocument defines the structure of InvoiceReferencedDocument of the CII standard
 type ReferencedDocument struct {
 	IssuerAssignedID string              `xml:"ram:IssuerAssignedID,omitempty"`
+	TypeCode         string              `xml:"ram:TypeCode,omitempty"`
 	IssueDate        *FormattedIssueDate `xml:"ram:FormattedIssueDateTime,omitempty"`
 }
 
@@ -163,6 +164,9 @@ func newSettlement(inv *bill.Invoice, ctx Context) (*Settlement, error) {
 		pre := inv.Preceding[0]
 		rd := &ReferencedDocument{
 			IssuerAssignedID: invoiceNumber(pre.Series, pre.Code),
+		}
+		if dt := pre.Ext.Get(untdid.ExtKeyDocumentType); dt != "" {
+			rd.TypeCode = dt.String()
 		}
 		// IssueDate (BT-26) is optional; only emit FormattedIssueDateTime when the
 		// preceding reference actually has a date, otherwise it renders as an empty
@@ -374,20 +378,23 @@ func newTax(inv *bill.Invoice, rate *tax.RateTotal, category *tax.CategoryTotal)
 	}
 	// BT-120: Set exemption reason from tax notes
 	if inv.Tax != nil {
-		if note := findTaxNote(inv.Tax.Notes, category.Code, rate); note != nil {
+		if note := findTaxNote(inv.Tax.Notes, category.Code, rate.Ext); note != nil {
 			t.ExemptionReason = note.Text
 		}
 	}
 	return t
 }
 
+// newPayee builds a minimal PayeeTradeParty, keeping only Name, ID,
+// GlobalID and the electronic address. Reflects rules from CII-SR-352 to
+// 364 and CII-SR-364. These rules are warnings but have been added as they
+// produce cleaner invoices.
 func newPayee(party *org.Party, ctx Context) *Party {
-	// Reflects rules from CII-SR-352 to 364 and CII-SR-364
-	// These rules are warnings but have been added as they produce cleaner invoices
 	p := newParty(party, ctx)
 	payee := &Party{
-		Name: p.Name,
-		ID:   p.ID,
+		Name:                      p.Name,
+		ID:                        p.ID,
+		URIUniversalCommunication: p.URIUniversalCommunication,
 	}
 
 	if payee.ID != nil {
@@ -428,12 +435,12 @@ func goblAddTaxNotes(taxes []*Tax, inv *bill.Invoice) {
 
 // findTaxNote finds a tax note that matches the given category code and rate total
 // by comparing category and the UNTDID tax category extension.
-func findTaxNote(notes []*tax.Note, catCode cbc.Code, rate *tax.RateTotal) *tax.Note {
+func findTaxNote(notes []*tax.Note, catCode cbc.Code, ext tax.Extensions) *tax.Note {
 	for _, n := range notes {
 		if n.Category != catCode {
 			continue
 		}
-		if nc := n.Ext.Get(untdid.ExtKeyTaxCategory); nc != "" && nc == rate.Ext.Get(untdid.ExtKeyTaxCategory) {
+		if nc := n.Ext.Get(untdid.ExtKeyTaxCategory); nc != "" && nc == ext.Get(untdid.ExtKeyTaxCategory) {
 			return n
 		}
 	}

--- a/settlement_parse.go
+++ b/settlement_parse.go
@@ -7,7 +7,6 @@ import (
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
-	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/tax"
 )
@@ -27,13 +26,7 @@ func goblNewPaymentDetails(stlm *Settlement) (*bill.PaymentDetails, error) {
 	pymt := &bill.PaymentDetails{}
 
 	if stlm.Payee != nil {
-		payee := &org.Party{Name: stlm.Payee.Name}
-		if stlm.Payee.PostalTradeAddress != nil {
-			payee.Addresses = []*org.Address{
-				goblNewAddress(stlm.Payee.PostalTradeAddress),
-			}
-		}
-		pymt.Payee = payee
+		pymt.Payee = goblNewParty(stlm.Payee)
 	}
 	if len(stlm.PaymentTerms) > 0 {
 		terms, err := goblNewTerms(stlm)

--- a/settlement_test.go
+++ b/settlement_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,8 @@ func TestNewSettlement(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "SAMPLE-001", doc.Transaction.Settlement.ReferencedDocument[0].IssuerAssignedID)
+		// BT-25 type code (UNTDID 1001), sourced from the preceding doc's untdid-document-type extension.
+		assert.Equal(t, "380", doc.Transaction.Settlement.ReferencedDocument[0].TypeCode)
 		assert.Equal(t, "20240213", doc.Transaction.Settlement.ReferencedDocument[0].IssueDate.DateFormat.Value)
 		assert.Equal(t, "102", doc.Transaction.Settlement.ReferencedDocument[0].IssueDate.DateFormat.Format)
 	})
@@ -175,6 +178,59 @@ func TestTaxPointConversion(t *testing.T) {
 			assert.Empty(t, tax.DueDateTypeCode)
 		}
 	})
+}
+
+func TestPayeeInboxRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/invoice-complete.json")
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotNil(t, inv.Payment)
+	inv.Payment.Payee = &org.Party{
+		Name: "Test Payee",
+		Inboxes: []*org.Inbox{
+			{Email: "payee@example.com"},
+		},
+	}
+
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.Transaction.Settlement.Payee)
+	require.NotNil(t, doc.Transaction.Settlement.Payee.URIUniversalCommunication)
+	assert.Equal(t, "payee@example.com", doc.Transaction.Settlement.Payee.URIUniversalCommunication.ID.Value)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotNil(t, parsedInv.Payment)
+	require.NotNil(t, parsedInv.Payment.Payee)
+	require.NotEmpty(t, parsedInv.Payment.Payee.Inboxes)
+	assert.Equal(t, "payee@example.com", parsedInv.Payment.Payee.Inboxes[0].Email)
+}
+
+func TestPrecedingDocumentTypeRoundTrip(t *testing.T) {
+	env := loadEnvelope(t, "en16931/correction-invoice.json")
+	doc, err := cii.ConvertInvoice(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, "380", doc.Transaction.Settlement.ReferencedDocument[0].TypeCode)
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	parsed, err := cii.Parse(data)
+	require.NoError(t, err)
+	parsedInv, ok := parsed.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	require.NotEmpty(t, parsedInv.Preceding)
+	assert.Equal(t, cbc.Code("380"), parsedInv.Preceding[0].Ext.Get(untdid.ExtKeyDocumentType))
 }
 
 func TestTaxPointRoundTrip(t *testing.T) {

--- a/test/data/convert/en16931/correction-invoice.json
+++ b/test/data/convert/en16931/correction-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9eff5f6ef3a471d0c991d98b4cd3da27b2ad789bee7418d1aafd8678354bd029"
+			"val": "f3636822b5513381ddb8748dd2ac71645070d8c999727d32bb4d512dcae6aafb"
 		}
 	},
 	"doc": {
@@ -23,7 +23,10 @@
 			{
 				"issue_date": "2024-02-13",
 				"series": "SAMPLE",
-				"code": "001"
+				"code": "001",
+				"ext": {
+					"untdid-document-type": "380"
+				}
 			}
 		],
 		"tax": {

--- a/test/data/convert/en16931/invoice-complete.json
+++ b/test/data/convert/en16931/invoice-complete.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "94ae7afa4e37e8fe9d9c60afbad226ca45ad7434e6af2ab448f40510edf0a508"
+			"val": "8d63c0340ff926f8c1d986c5a0309a7f9858517bab7d7731aeae9013d94acbf4"
 		}
 	},
 	"doc": {
@@ -167,7 +167,8 @@
 			},
 			"contracts": [
 				{
-					"code": "2013-05"
+					"code": "2013-05",
+					"reason": "MARCHE"
 				}
 			],
 			"receiving": [

--- a/test/data/convert/en16931/out/correction-invoice.xml
+++ b/test/data/convert/en16931/out/correction-invoice.xml
@@ -102,6 +102,7 @@
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
       <ram:InvoiceReferencedDocument>
         <ram:IssuerAssignedID>SAMPLE-001</ram:IssuerAssignedID>
+        <ram:TypeCode>380</ram:TypeCode>
         <ram:FormattedIssueDateTime>
           <qdt:DateTimeString format="102">20240213</qdt:DateTimeString>
         </ram:FormattedIssueDateTime>

--- a/test/data/convert/en16931/out/invoice-complete.xml
+++ b/test/data/convert/en16931/out/invoice-complete.xml
@@ -92,6 +92,7 @@
       </ram:BuyerTradeParty>
       <ram:ContractReferencedDocument>
         <ram:IssuerAssignedID>2013-05</ram:IssuerAssignedID>
+        <ram:ReferenceTypeCode>MARCHE</ram:ReferenceTypeCode>
       </ram:ContractReferencedDocument>
     </ram:ApplicableHeaderTradeAgreement>
     <ram:ApplicableHeaderTradeDelivery>

--- a/utils_parse.go
+++ b/utils_parse.go
@@ -1,9 +1,6 @@
 package cii
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 )
@@ -21,15 +18,4 @@ func goblUnitFromUNECE(unece cbc.Code) org.Unit {
 	// If no match is found, return the original UN/ECE code as a Unit
 	unit := org.Unit(unece)
 	return unit
-}
-
-func formatKey(key string) cbc.Key {
-	key = strings.ToLower(key)
-	key = strings.ReplaceAll(key, " ", "-")
-	re := regexp.MustCompile(`[^a-z0-9-+]`)
-	key = re.ReplaceAllString(key, "")
-	key = strings.Trim(key, "-+")
-	re = regexp.MustCompile(`[-+]{2,}`)
-	key = re.ReplaceAllString(key, "-")
-	return cbc.Key(key)
 }


### PR DESCRIPTION
## What

CII counterpart to invopop/gobl.ubl#128. Several EN16931/Factur-X/XRechnung
mapping gaps found while building out the French extended
(EXTENDED-CTC-FR) profile. Bundled into one PR since they touch
overlapping files.

- **Item attributes.** Migrate `org.Item.Meta` (a lossy string map) to
  `org.Item.Attributes`, matching the current GOBL API. Rendered as
  `ApplicableProductCharacteristic`; unlike UBL, CII has no
  quantity+unit element, so a quantity attribute always round-trips as
  text.
- **Line seller.** Map `bill.Line.Seller` to/from
  `ram:ItemSellerTradeParty`.
- **Line notes.** Reuse the `untdid-text-subject` extension for line
  notes' subject code, instead of the removed `org.Note.Key`.
- **Contract reason.** Map `org.Contract.Reason` to/from
  `ram:ReferenceTypeCode` on `ContractReferencedDocument` — previously
  only the contract ID was mapped.
- **Preceding document type (BT-25).** Map the preceding document's
  `untdid-document-type` extension to/from `ram:TypeCode` on
  `InvoiceReferencedDocument`.
- **Charge/discount exemption codes.** Map the CEF VATEX extension and
  matching tax note text onto `AllowanceCharge/Tax`
  (`ExemptionReasonCode`/`ExemptionReason`), mirroring what `newTax`
  already does for the invoice totals — but only at document level;
  line-level `ApplicableTradeTax` does not accept
  `ExemptionReasonCode` in at least the Factur-X profile. `findTaxNote`
  now takes `tax.Extensions` directly so both call sites share it.
- **Payee electronic address.** Map payee inboxes to/from
  `URIUniversalCommunication`, same as other parties.

## Test data

Convert/parse goldens regenerated with `-update`; diffs are limited to
the fields above.

**Note:** `settlement.go`'s `newPayee` (a minimal `Party` builder
reflecting CII-SR-352 to 364 — warnings, but they produce cleaner
invoices by omitting the payee's address/tax/legal details) was
calling the shared `newParty` directly in the original WIP, which
reintroduced a `PostalTradeAddress` onto `PayeeTradeParty` on every
fixture with a payee address. Restored the trim, keeping
`Name`/`ID`/`GlobalID` plus the new `URIUniversalCommunication`
mapping — verified all four affected golden fixtures
(en16931/facturx/peppol/xrechnung) are back to byte-identical except
for the intended `ReferenceTypeCode`/`TypeCode` additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)